### PR TITLE
Proactive shuffle file cleanup

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -667,6 +667,8 @@ message Action {
   oneof ActionType {
     // Fetch a partition from an executor
     FetchPartition fetch_partition = 3;
+    // Delete a partition on an executor
+    DeletePartition delete_partition = 4;
   }
 
   // configuration settings
@@ -689,6 +691,10 @@ message FetchPartition {
   uint32 stage_id = 2;
   uint32 partition_id = 3;
   string path = 4;
+}
+
+message DeletePartition {
+  string path = 1;
 }
 
 // Mapping from partition id to executor id

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -831,7 +831,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                 .groups()
                 .iter()
                 .flatten()
-                .map(|b| *b)
+                .copied()
                 .collect();
 
             let null_expr = exec
@@ -1363,7 +1363,7 @@ mod roundtrip_tests {
 
         let null_expr: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![
             (lit(ScalarValue::Int64(None)), "a".to_string()),
-            ((lit(ScalarValue::Int64(None)), "b".to_string())),
+            (lit(ScalarValue::Int64(None)), "b".to_string()),
         ];
 
         let aggregates: Vec<Arc<dyn AggregateExpr>> = vec![Arc::new(Avg::new(

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -361,11 +361,15 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     })
                     .collect::<Result<Vec<_>, _>>()?;
 
-                let groups: Vec<Vec<bool>> = hash_agg
-                    .groups
-                    .chunks(num_expr)
-                    .map(|g| g.to_vec())
-                    .collect::<Vec<Vec<bool>>>();
+                let groups: Vec<Vec<bool>> = if !hash_agg.groups.is_empty() {
+                    hash_agg
+                        .groups
+                        .chunks(num_expr)
+                        .map(|g| g.to_vec())
+                        .collect::<Vec<Vec<bool>>>()
+                } else {
+                    vec![]
+                };
 
                 let input_schema = hash_agg
                     .input_schema

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -33,6 +33,9 @@ impl TryInto<Action> for protobuf::Action {
                 partition_id: fetch.partition_id as usize,
                 path: fetch.path,
             }),
+            Some(ActionType::DeletePartition(delete)) => {
+                Ok(Action::DeletePartition { path: delete.path })
+            }
             _ => Err(BallistaError::General(
                 "scheduler::from_proto(Action) invalid or missing action".to_owned(),
             )),

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -42,6 +42,9 @@ pub enum Action {
         partition_id: usize,
         path: String,
     },
+    DeletePartition {
+        path: String,
+    },
 }
 
 /// Unique identifier for the output partition of an operator.

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -42,6 +42,12 @@ impl TryInto<protobuf::Action> for Action {
                 })),
                 settings: vec![],
             }),
+            Action::DeletePartition { path } => Ok(protobuf::Action {
+                action_type: Some(ActionType::DeletePartition(
+                    protobuf::DeletePartition { path },
+                )),
+                settings: vec![],
+            }),
         }
     }
 }

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -168,7 +168,7 @@ impl FlightService for BallistaFlightService {
             decode_protobuf(&action.body.to_vec()).map_err(|e| from_ballista_err(&e))?;
 
         match &action {
-            BallistaAction::FetchPartition { path, .. } => {
+            BallistaAction::DeletePartition { path } => {
                 info!("DeletePartition deleting {}", &path);
                 std::fs::remove_file(&path)
                     .map_err(|e| {

--- a/ballista/rust/scheduler/src/scheduler_server/event.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/event.rs
@@ -19,6 +19,7 @@ use crate::state::executor_manager::ExecutorReservation;
 
 use datafusion::logical_plan::LogicalPlan;
 
+use ballista_core::serde::scheduler::PartitionLocation;
 use datafusion::prelude::SessionContext;
 use std::sync::Arc;
 
@@ -37,6 +38,6 @@ pub enum QueryStageSchedulerEvent {
         plan: Box<LogicalPlan>,
     },
     JobSubmitted(String),
-    JobFinished(String),
+    JobFinished(String, Vec<PartitionLocation>),
     JobFailed(String, String),
 }

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -629,6 +629,19 @@ impl ExecutionGraph {
         Ok(())
     }
 
+    pub fn intermediate_shuffle_locations(&self) -> Vec<PartitionLocation> {
+        let mut locations: Vec<PartitionLocation> = vec![];
+        self.stages.iter().for_each(|(_, stage)| {
+            stage.inputs.iter().for_each(|(_, stage_output)| {
+                stage_output
+                    .partition_locations
+                    .iter()
+                    .for_each(|(_, locs)| locations.extend(locs.clone()));
+            })
+        });
+        locations
+    }
+
     pub fn update_status(&mut self, status: JobStatus) {
         self.status = status;
     }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -40,6 +40,7 @@ pub mod execution_graph;
 pub mod executor_manager;
 pub mod session_manager;
 pub mod session_registry;
+pub mod shuffle_reaper;
 mod task_manager;
 
 pub fn decode_protobuf<T: Message + Default>(bytes: &[u8]) -> Result<T> {

--- a/ballista/rust/scheduler/src/state/shuffle_reaper.rs
+++ b/ballista/rust/scheduler/src/state/shuffle_reaper.rs
@@ -1,0 +1,52 @@
+use ballista_core::client::BallistaClient;
+use ballista_core::serde::scheduler::PartitionLocation;
+use log::error;
+use std::collections::HashMap;
+use tokio::sync::mpsc::Receiver;
+
+pub struct ShuffleReaper {
+    receiver: Receiver<Vec<PartitionLocation>>,
+}
+
+impl ShuffleReaper {
+    pub fn new(receiver: Receiver<Vec<PartitionLocation>>) -> Self {
+        Self { receiver }
+    }
+
+    pub fn start(self) {
+        tokio::task::spawn(async move {
+            let mut clients: HashMap<String, BallistaClient> = Default::default();
+            let mut receiver = self.receiver;
+            while let Some(locations) = receiver.recv().await {
+                for location in locations {
+                    if let Some(client) = clients.get_mut(&location.executor_meta.id) {
+                        match client.delete_partition(&location.path).await {
+                            Ok(()) => (),
+                            Err(e) => error!(
+                                "Error deleting partition {:?} from executor {:?}: {:?}",
+                                location.path, location.executor_meta.id, e
+                            ),
+                        }
+                    } else {
+                        let executor_id = location.executor_meta.id.clone();
+                        if let Ok(mut client) = BallistaClient::try_new(
+                            &location.executor_meta.host,
+                            location.executor_meta.grpc_port,
+                        )
+                        .await
+                        {
+                            clients.insert(executor_id, client.clone());
+                            match client.delete_partition(&location.path)
+                                .await {
+                                Ok(()) => (),
+                                Err(e) => error!("Error deleting partition {:?} from executor {:?}: {:?}", location.path, location.executor_meta.id,e)
+                            }
+                        } else {
+                            error!("Failed to connect to executor {}", executor_id);
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/ballista/rust/scheduler/src/state/shuffle_reaper.rs
+++ b/ballista/rust/scheduler/src/state/shuffle_reaper.rs
@@ -20,13 +20,15 @@ impl ShuffleReaper {
             while let Some(locations) = receiver.recv().await {
                 for location in locations {
                     if let Some(client) = clients.get_mut(&location.executor_meta.id) {
-                        match client.delete_partition(&location.path).await {
-                            Ok(()) => (),
-                            Err(e) => error!(
+                        client
+                            .delete_partition(&location.path)
+                            .await
+                            .unwrap_or_else(|e| {
+                                error!(
                                 "Error deleting partition {:?} from executor {:?}: {:?}",
                                 location.path, location.executor_meta.id, e
-                            ),
-                        }
+                            )
+                            });
                     } else {
                         let executor_id = location.executor_meta.id.clone();
                         if let Ok(mut client) = BallistaClient::try_new(
@@ -36,11 +38,9 @@ impl ShuffleReaper {
                         .await
                         {
                             clients.insert(executor_id, client.clone());
-                            match client.delete_partition(&location.path)
-                                .await {
-                                Ok(()) => (),
-                                Err(e) => error!("Error deleting partition {:?} from executor {:?}: {:?}", location.path, location.executor_meta.id,e)
-                            }
+                            client.delete_partition(&location.path).await.unwrap_or_else(|e| {
+                                error!("Error deleting partition {:?} from executor {:?}: {:?}", location.path, location.executor_meta.id,e)
+                            });
                         } else {
                             error!("Failed to connect to executor {}", executor_id);
                         }

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -184,7 +184,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                         graph.job_id()
                     );
                     graph.finalize()?;
-                    events.push(QueryStageSchedulerEvent::JobFinished(job_id.clone()));
+                    let intermediate_shuffles = graph.intermediate_shuffle_locations();
+                    events.push(QueryStageSchedulerEvent::JobFinished(
+                        job_id.clone(),
+                        intermediate_shuffles,
+                    ));
                 } else if let Some(job_status::Status::Failed(failure)) =
                     graph.status().status
                 {


### PR DESCRIPTION
Cleanup intermediate shuffle files when a job completes. 

In the current setup we just have a timed task that will cleanup shuffle files on a scheduler (using a TTL). This isn't great because we have to balance the TTL against disk space pressure and it's not clear how we can do that effectively. 

This will cleanup intermediate shuffle files once the job completes. 