### PR TITLE
Scheduler fixes

### DIFF
--- a/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -133,11 +133,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                         .map(|res| res.assign(job_id.clone()))
                         .collect();
 
-                    if reservations.is_empty() {
-                        debug!("Resubmitting job {}", job_id);
-                        return Ok(Some(QueryStageSchedulerEvent::JobSubmitted(job_id)));
-                    }
-
                     debug!(
                         "Reserved {} task slots for submitted job {}",
                         reservations.len(),


### PR DESCRIPTION
Fixing a few issues discovered in push-based scheduling:

1. Executor reservations were not getting freed after job was completed. 
2. Rearranged order of job status checks to avoid concurrency issues when a job is moved from queued -> active. That move is atomic so we need to check if job is queued first. Otherwise, the job may be moved from queued -> active between the active jobs check and the queued jobs check. 