### PR TITLE
Sc 7041

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -339,6 +339,8 @@ message ShuffleWriterExecNode {
   uint32 stage_id = 2;
   PhysicalPlanNode input = 3;
   PhysicalHashRepartition output_partitioning = 4;
+  uint64 max_shuffle_bytes = 5;
+
 }
 
 message ShuffleReaderExecNode {

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -161,7 +161,7 @@ impl ShuffleWriterExec {
         let write_metrics = ShuffleWriteMetrics::new(input_partition, &self.metrics);
         let output_partitioning = self.shuffle_output_partitioning.clone();
         let plan = self.plan.clone();
-        let max_shuffle_bytes = self.max_shuffle_bytes.clone();
+        let max_shuffle_bytes = self.max_shuffle_bytes;
 
         async move {
             let now = Instant::now();
@@ -242,7 +242,7 @@ impl ShuffleWriterExec {
                                     Some(w) => {
                                         let cur_bytes = w.num_bytes;
                                         w.write(&output_batch)?;
-                                        total_bytes_count.fetch_add(((w.num_bytes - cur_bytes)) as usize, Ordering::SeqCst);
+                                        total_bytes_count.fetch_add((w.num_bytes - cur_bytes) as usize, Ordering::SeqCst);
                                     }
                                     None => {
                                         let mut path = path.clone();
@@ -262,7 +262,7 @@ impl ShuffleWriterExec {
 
                                         let cur_bytes = writer.num_bytes;
                                         writer.write(&output_batch)?;
-                                        total_bytes_count.fetch_add(((writer.num_bytes - cur_bytes)) as usize, Ordering::Acquire);
+                                        total_bytes_count.fetch_add((writer.num_bytes - cur_bytes) as usize, Ordering::Acquire);
 
                                         writers[output_partition] = Some(writer);
                                     }
@@ -361,7 +361,7 @@ impl ExecutionPlan for ShuffleWriterExec {
             children[0].clone(),
             self.work_dir.clone(),
             self.shuffle_output_partitioning.clone(),
-            self.max_shuffle_bytes.clone(),
+            self.max_shuffle_bytes,
         )?))
     }
 

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -577,12 +577,19 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     input.schema().as_ref(),
                 )?;
 
+                let max_shuffle_bytes = if shuffle_writer.max_shuffle_bytes == 0 {
+                    None
+                } else {
+                    Some(shuffle_writer.max_shuffle_bytes as usize)
+                };
+
                 Ok(Arc::new(ShuffleWriterExec::try_new(
                     shuffle_writer.job_id.clone(),
                     shuffle_writer.stage_id as usize,
                     input,
                     "".to_string(), // this is intentional but hacky - the executor will fill this in
                     output_partitioning,
+                    max_shuffle_bytes,
                 )?))
             }
             PhysicalPlanType::ShuffleReader(shuffle_reader) => {
@@ -1099,6 +1106,10 @@ impl AsExecutionPlan for PhysicalPlanNode {
                         stage_id: exec.stage_id() as u32,
                         input: Some(Box::new(input)),
                         output_partitioning,
+                        max_shuffle_bytes: exec
+                            .max_shuffle_bytes()
+                            .map(|max| max as u64)
+                            .unwrap_or(0),
                     },
                 ))),
             })
@@ -1475,6 +1486,7 @@ mod roundtrip_tests {
             Arc::new(EmptyExec::new(false, schema)),
             "".to_string(),
             Some(Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 4)),
+            None,
         )?))
     }
 

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -57,6 +57,7 @@ pub async fn write_stream_to_disk(
     stream: &mut Pin<Box<dyn RecordBatchStream + Send>>,
     path: &str,
     disk_write_metric: &metrics::Time,
+    max_bytes: Option<usize>,
 ) -> Result<PartitionStats> {
     let file = File::create(&path).map_err(|e| {
         BallistaError::General(format!(
@@ -77,6 +78,15 @@ pub async fn write_stream_to_disk(
         num_batches += 1;
         num_rows += batch.num_rows();
         num_bytes += batch_size_bytes;
+
+        if let Some(max_bytes) = max_bytes {
+            if num_bytes > max_bytes {
+                return Err(BallistaError::General(format!(
+                    "Exceeded limit on max bytes written to disk: {:?}",
+                    max_bytes
+                )));
+            }
+        }
 
         let timer = disk_write_metric.timer();
         writer.write(&batch)?;

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -126,6 +126,7 @@ impl Executor {
                 plan.children()[0].clone(),
                 self.work_dir.clone(),
                 shuffle_writer.shuffle_output_partitioning().cloned(),
+                shuffle_writer.max_shuffle_bytes(),
             )
         } else {
             Err(DataFusionError::Internal(
@@ -290,6 +291,7 @@ mod test {
             1,
             Arc::new(NeverendingOperator),
             work_dir.clone(),
+            None,
             None,
         )
         .expect("creating shuffle writer");

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -75,7 +75,7 @@ impl DistributedPlanner {
             self.next_stage_id(),
             new_plan,
             None,
-            self.max_shuffle_bytes.clone(),
+            self.max_shuffle_bytes,
         )?);
         Ok(stages)
     }

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -40,11 +40,15 @@ type PartialQueryStageResult = (Arc<dyn ExecutionPlan>, Vec<Arc<ShuffleWriterExe
 
 pub struct DistributedPlanner {
     next_stage_id: usize,
+    max_shuffle_bytes: Option<usize>,
 }
 
 impl DistributedPlanner {
     pub fn new() -> Self {
-        Self { next_stage_id: 0 }
+        Self {
+            next_stage_id: 0,
+            max_shuffle_bytes: Some(50 * 1024 * 1024 * 1024),
+        }
     }
 }
 
@@ -71,6 +75,7 @@ impl DistributedPlanner {
             self.next_stage_id(),
             new_plan,
             None,
+            self.max_shuffle_bytes.clone(),
         )?);
         Ok(stages)
     }
@@ -107,6 +112,7 @@ impl DistributedPlanner {
                 self.next_stage_id(),
                 children[0].clone(),
                 None,
+                self.max_shuffle_bytes,
             )?;
             let unresolved_shuffle = Arc::new(UnresolvedShuffleExec::new(
                 shuffle_writer.stage_id(),
@@ -134,6 +140,7 @@ impl DistributedPlanner {
                         self.next_stage_id(),
                         children[0].clone(),
                         Some(repart.partitioning().to_owned()),
+                        self.max_shuffle_bytes,
                     )?;
                     let unresolved_shuffle = Arc::new(UnresolvedShuffleExec::new(
                         shuffle_writer.stage_id(),
@@ -251,6 +258,7 @@ fn create_shuffle_writer(
     stage_id: usize,
     plan: Arc<dyn ExecutionPlan>,
     partitioning: Option<Partitioning>,
+    max_shuffle_bytes: Option<usize>,
 ) -> Result<Arc<ShuffleWriterExec>> {
     Ok(Arc::new(ShuffleWriterExec::try_new(
         job_id.to_owned(),
@@ -258,6 +266,7 @@ fn create_shuffle_writer(
         plan,
         "".to_owned(), // executor will decide on the work_dir path
         partitioning,
+        max_shuffle_bytes,
     )?))
 }
 


### PR DESCRIPTION
Which issue does this PR close?
https://app.shortcut.com/coralogix/story/7041/implement-limits-on-disk-usage-for-shuffle-files-on-a-query-level-basis

Rationale for this change
We need to ensure that one query doesn't fill up a nodes disk.

What changes are included in this PR?
This change adds limits on the disk usage on shuffles.