### PR TITLE
passing `queued_at` in completed job status

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -692,6 +692,7 @@ message GetJobStatusParams {
 
 message CompletedJob {
   repeated PartitionLocation partition_location = 1;
+  uint64 queued_at = 2;
 }
 
 message QueuedJob {}

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -680,6 +680,7 @@ impl ExecutionGraph {
         self.status = JobStatus {
             status: Some(job_status::Status::Completed(CompletedJob {
                 partition_location,
+                queued_at: self.queued_at
             })),
         };
 


### PR DESCRIPTION
Exposing `queued_at` in complete job status