### PR TITLE
Catch panics in task execution so jobs do not hang

### DIFF
--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -647,24 +647,30 @@ impl ExecutionGraph {
         for event in events {
             match event {
                 StageEvent::StageResolved(stage_id) => {
+                    info!("stage {}/{} resolved", self.job_id, stage_id);
                     self.resolve_stage(stage_id)?;
                     has_resolved = true;
                 }
                 StageEvent::StageCompleted(stage_id) => {
+                    info!("stage {}/{} completed", self.job_id, stage_id);
                     self.complete_stage(stage_id);
                 }
                 StageEvent::StageFailed(stage_id, err_msg, failed_at) => {
+                    error!("stage {}/{} failed: {}", self.job_id, stage_id, err_msg);
                     job_err_msg = format!("{}{}\n", job_err_msg, &err_msg);
                     failed_at_time = failed_at;
                     self.fail_stage(stage_id, err_msg);
                 }
                 StageEvent::RollBackRunningStage(stage_id) => {
+                    warn!("running stage {}/{} rolled back", self.job_id, stage_id);
                     self.rollback_running_stage(stage_id)?;
                 }
                 StageEvent::RollBackResolvedStage(stage_id) => {
+                    warn!("running stage {}/{} rolled back", self.job_id, stage_id);
                     self.rollback_resolved_stage(stage_id)?;
                 }
                 StageEvent::ReRunCompletedStage(stage_id) => {
+                    info!("re-running completed stage {}/{}", self.job_id, stage_id);
                     self.rerun_completed_stage(stage_id);
                 }
             }

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -151,7 +151,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         let mut events: Vec<QueryStageSchedulerEvent> = vec![];
         for (job_id, statuses) in job_updates {
             let num_tasks = statuses.len();
-            debug!("Updating {} tasks in job {}", num_tasks, job_id);
+            info!("Updating {} tasks in job {}", num_tasks, job_id);
 
             let graph = self.get_active_execution_graph(&job_id).await;
             let job_event = if let Some(graph) = graph {


### PR DESCRIPTION
Make sure we catch any panics during task execution so we can properly report task failures to the scheduler. This uses the same approach that was already implemented for pull-based scheduling. 

Also add some additional logging to help debug scheduler issues