### PR TITLE
Use node-level local limit

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -43,8 +43,10 @@ datafusion = { path = "../../../datafusion" }
 futures = "0.3"
 hashbrown = "0.12"
 
+lazy_static = "1.4.0"
 libloading = "0.7.3"
 log = "0.4"
+lru = "0.8.1"
 object_store = "0.5.0"
 once_cell = "1.9.0"
 

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -348,7 +348,9 @@ message ShuffleWriterExecNode {
   PhysicalPlanNode input = 3;
   PhysicalHashRepartition output_partitioning = 4;
   uint64 max_shuffle_bytes = 5;
-  optional uint64 limit = 6;
+  oneof optional_limit {
+    uint64 limit = 6;
+  }
 }
 
 message ShuffleReaderExecNode {

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -348,7 +348,7 @@ message ShuffleWriterExecNode {
   PhysicalPlanNode input = 3;
   PhysicalHashRepartition output_partitioning = 4;
   uint64 max_shuffle_bytes = 5;
-
+  optional uint64 limit = 6;
 }
 
 message ShuffleReaderExecNode {

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -162,7 +162,7 @@ impl ShuffleWriterExec {
         work_dir: String,
         shuffle_output_partitioning: Option<Partitioning>,
         max_shuffle_bytes: Option<usize>,
-        limit: usize,
+        limit: Option<usize>,
     ) -> Result<Self> {
         Ok(Self {
             job_id,
@@ -172,7 +172,7 @@ impl ShuffleWriterExec {
             shuffle_output_partitioning,
             metrics: ExecutionPlanMetricsSet::new(),
             max_shuffle_bytes,
-            limit: Some(limit),
+            limit,
         })
     }
 
@@ -194,6 +194,10 @@ impl ShuffleWriterExec {
     /// Get the max shuffle bytes
     pub fn max_shuffle_bytes(&self) -> Option<usize> {
         self.max_shuffle_bytes
+    }
+
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
     }
 
     pub fn execute_shuffle_write(

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -429,13 +429,14 @@ impl ExecutionPlan for ShuffleWriterExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(ShuffleWriterExec::try_new(
+        Ok(Arc::new(ShuffleWriterExec::try_new_with_limit(
             self.job_id.clone(),
             self.stage_id,
             children[0].clone(),
             self.work_dir.clone(),
             self.shuffle_output_partitioning.clone(),
             self.max_shuffle_bytes,
+            self.limit,
         )?))
     }
 

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -57,7 +57,29 @@ use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::repartition::BatchPartitioner;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use lazy_static::lazy_static;
 use log::{debug, error, info};
+use lru::LruCache;
+use parking_lot::Mutex;
+use std::num::NonZeroUsize;
+
+lazy_static! {
+    static ref LIMIT_ACCUMULATORS: Mutex<LruCache<(String, usize), Arc<AtomicUsize>>> =
+        Mutex::new(LruCache::new(NonZeroUsize::new(10).unwrap()));
+}
+
+fn get_limit_accumulator(job_id: &str, stage: usize) -> Arc<AtomicUsize> {
+    let mut guard = LIMIT_ACCUMULATORS.lock();
+
+    if let Some(accumulator) = guard.get(&(job_id.to_owned(), stage)) {
+        accumulator.clone()
+    } else {
+        let accumulator = Arc::new(AtomicUsize::new(0));
+        guard.push((job_id.to_owned(), stage), accumulator.clone());
+
+        accumulator
+    }
+}
 
 /// ShuffleWriterExec represents a section of a query plan that has consistent partitioning and
 /// can be executed as one unit with each partition being executed in parallel. The output of each
@@ -79,6 +101,8 @@ pub struct ShuffleWriterExec {
     metrics: ExecutionPlanMetricsSet,
     /// Maximum shuffle bytes written per node
     max_shuffle_bytes: Option<usize>,
+    /// Maximum number of rows to return
+    limit: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +151,28 @@ impl ShuffleWriterExec {
             shuffle_output_partitioning,
             metrics: ExecutionPlanMetricsSet::new(),
             max_shuffle_bytes,
+            limit: None,
+        })
+    }
+
+    pub fn try_new_with_limit(
+        job_id: String,
+        stage_id: usize,
+        plan: Arc<dyn ExecutionPlan>,
+        work_dir: String,
+        shuffle_output_partitioning: Option<Partitioning>,
+        max_shuffle_bytes: Option<usize>,
+        limit: usize,
+    ) -> Result<Self> {
+        Ok(Self {
+            job_id,
+            stage_id,
+            plan,
+            work_dir,
+            shuffle_output_partitioning,
+            metrics: ExecutionPlanMetricsSet::new(),
+            max_shuffle_bytes,
+            limit: Some(limit),
         })
     }
 
@@ -164,6 +210,10 @@ impl ShuffleWriterExec {
         let plan = self.plan.clone();
         let max_shuffle_bytes = self.max_shuffle_bytes;
 
+        let limit_and_accumulator = self
+            .limit
+            .map(|l| (l, get_limit_accumulator(&self.job_id, self.stage_id)));
+
         async move {
             let now = Instant::now();
             let mut stream = match plan.execute(input_partition, context) {
@@ -193,6 +243,7 @@ impl ShuffleWriterExec {
                         path,
                         &write_metrics.write_time,
                         max_shuffle_bytes,
+                        limit_and_accumulator,
                     )
                     .await
                     .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
@@ -238,6 +289,8 @@ impl ShuffleWriterExec {
 
                     while let Some(result) = stream.next().await {
                         let input_batch = result?;
+
+                        let num_rows = input_batch.num_rows();
 
                         write_metrics.input_rows.add(input_batch.num_rows());
 
@@ -293,6 +346,13 @@ impl ShuffleWriterExec {
                                 Ok(())
                             },
                         )?;
+
+                        if let Some((limit, accum)) = limit_and_accumulator.as_ref() {
+                            let total_rows = accum.fetch_add(num_rows, Ordering::SeqCst);
+                            if total_rows > *limit {
+                                break;
+                            }
+                        }
                     }
 
                     let mut part_locs = vec![];

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -46,6 +46,7 @@ use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::{metrics, ExecutionPlan, RecordBatchStream};
 use futures::StreamExt;
+use log::info;
 use std::io::{BufWriter, Write};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -100,6 +101,7 @@ pub async fn write_stream_to_disk(
         if let Some((limit, accum)) = limit.as_ref() {
             let total_rows = accum.fetch_add(num_rows, Ordering::SeqCst);
             if total_rows > *limit {
+                info!("stopping shuffle write early (path: {})", path);
                 break;
             }
         }

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -165,13 +165,14 @@ impl Executor {
             plan.as_any().downcast_ref::<ShuffleWriterExec>()
         {
             // recreate the shuffle writer with the correct working directory
-            ShuffleWriterExec::try_new(
+            ShuffleWriterExec::try_new_with_limit(
                 job_id,
                 stage_id,
                 plan.children()[0].clone(),
                 self.work_dir.clone(),
                 shuffle_writer.shuffle_output_partitioning().cloned(),
                 shuffle_writer.max_shuffle_bytes(),
+                shuffle_writer.limit(),
             )
         } else {
             Err(DataFusionError::Internal(

--- a/ballista/rust/executor/src/executor_server.rs
+++ b/ballista/rust/executor/src/executor_server.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ops::Deref;
 use std::panic::AssertUnwindSafe;
+
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{mpsc, RwLock};

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -299,7 +299,7 @@ fn create_shuffle_writer(
             "".to_owned(), // executor will decide on the work_dir path
             partitioning,
             max_shuffle_bytes,
-            local_limit_exec.fetch(),
+            Some(local_limit_exec.fetch()),
         )?))
     } else {
         Ok(Arc::new(ShuffleWriterExec::try_new(

--- a/ballista/rust/scheduler/src/scheduler_server/external_scaler.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/external_scaler.rs
@@ -57,8 +57,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExternalScaler
         Ok(Response::new(GetMetricsResponse {
             metric_values: vec![MetricValue {
                 metric_name: INFLIGHT_TASKS_METRIC_NAME.to_string(),
-                metric_value: self.state.task_manager.get_pending_task_queue_size()
-                    as i64,
+                metric_value: 10000000, // A very high number to saturate the HPA
             }],
         }))
     }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -351,36 +351,23 @@ mod test {
 
         let plan = test_graph(session_ctx.clone()).await;
 
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 0);
-
         // Create 4 jobs so we have four pending tasks
         state
             .task_manager
             .submit_job("job-1", session_ctx.session_id().as_str(), plan.clone(), 0)
             .await?;
-
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 1);
-
         state
             .task_manager
             .submit_job("job-2", session_ctx.session_id().as_str(), plan.clone(), 0)
             .await?;
-
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 2);
-
         state
             .task_manager
             .submit_job("job-3", session_ctx.session_id().as_str(), plan.clone(), 0)
             .await?;
-
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 3);
-
         state
             .task_manager
             .submit_job("job-4", session_ctx.session_id().as_str(), plan.clone(), 0)
             .await?;
-
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 4);
 
         let executors = test_executors(1, 4);
 
@@ -394,7 +381,6 @@ mod test {
         let result = state.offer_reservation(reservations).await?;
 
         assert!(result.is_empty());
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 0);
 
         // All task slots should be assigned so we should not be able to reserve more tasks
         let reservations = state.executor_manager.reserve_slots(4).await?;
@@ -422,15 +408,11 @@ mod test {
 
         let plan = test_graph(session_ctx.clone()).await;
 
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 0);
-
         // Create a job
         state
             .task_manager
             .submit_job("job-1", session_ctx.session_id().as_str(), plan.clone(), 0)
             .await?;
-
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 1);
 
         let executors = test_executors(1, 4);
 
@@ -468,8 +450,6 @@ mod test {
             )
             .await?;
 
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 1);
-
         state
             .executor_manager
             .register_executor(executor_metadata, executor_data, false)
@@ -479,15 +459,11 @@ mod test {
 
         assert_eq!(reservations.len(), 1);
 
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 1);
-
         // Offer the reservation. It should be filled with one of the 4 pending tasks. The other 3 should
         // be reserved for the other 3 tasks, emitting another offer event
         let reservations = state.offer_reservation(reservations).await?;
 
         assert_eq!(reservations.len(), 3);
-
-        assert_eq!(state.task_manager.get_pending_task_queue_size(), 0);
 
         // Remaining 3 task slots should be reserved for pending tasks
         let reservations = state.executor_manager.reserve_slots(4).await?;

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -22,6 +22,7 @@ use crate::state::execution_graph::{ExecutionGraph, Task};
 use crate::state::executor_manager::{ExecutorManager, ExecutorReservation};
 use crate::state::{decode_protobuf, encode_protobuf, with_lock};
 use ballista_core::config::BallistaConfig;
+#[cfg(not(test))]
 use ballista_core::error::BallistaError;
 use ballista_core::error::Result;
 use ballista_core::serde::protobuf::executor_grpc_client::ExecutorGrpcClient;
@@ -41,7 +42,6 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 use std::default::Default;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
@@ -60,7 +60,6 @@ pub struct TaskManager<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
     scheduler_id: String,
     // Cache for active execution graphs curated by this scheduler
     active_job_cache: ExecutionGraphCache,
-    pending_task_queue_size: Arc<AtomicUsize>,
 }
 
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U> {
@@ -77,7 +76,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             codec,
             scheduler_id,
             active_job_cache: Arc::new(RwLock::new(HashMap::new())),
-            pending_task_queue_size: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -103,12 +101,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .await?;
 
         graph.revive();
-        let available_tasks = graph.available_tasks();
 
         let mut active_graph_cache = self.active_job_cache.write().await;
         active_graph_cache.insert(job_id.to_owned(), Arc::new(RwLock::new(graph)));
 
-        self.increase_pending_queue_size(available_tasks)
+        Ok(())
     }
 
     /// Get the status of of a job. First look in the active cache.
@@ -202,19 +199,16 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         let mut pending_tasks = 0usize;
         let mut assign_tasks = 0usize;
         let job_cache = self.active_job_cache.read().await;
-
         for (_job_id, graph) in job_cache.iter() {
             let mut graph = graph.write().await;
             for reservation in free_reservations.iter().skip(assign_tasks) {
                 if let Some(task) = graph.pop_next_task(&reservation.executor_id)? {
                     assignments.push((reservation.executor_id.clone(), task));
                     assign_tasks += 1;
-                    self.decrease_pending_queue_size(1)?;
                 } else {
                     break;
                 }
             }
-
             if assign_tasks >= free_reservations.len() {
                 pending_tasks = graph.available_tasks();
                 break;
@@ -259,6 +253,18 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     ) -> Result<()> {
         let lock = self.state.lock(Keyspace::ActiveJobs, "").await?;
 
+        let running_tasks = self
+            .get_execution_graph(job_id)
+            .await
+            .map(|graph| graph.running_tasks())
+            .unwrap_or_else(|_| vec![]);
+
+        info!(
+            "Cancelling {} running tasks for job {}",
+            running_tasks.len(),
+            job_id
+        );
+
         let failed_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
@@ -267,47 +273,39 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         self.fail_job_inner(lock, job_id, "Cancelled".to_owned(), failed_at)
             .await?;
 
-        if let Ok(graph) = self.get_execution_graph(job_id).await {
-            let running_tasks = graph.running_tasks();
-            let mut tasks: HashMap<&str, Vec<protobuf::PartitionId>> = Default::default();
+        let mut tasks: HashMap<&str, Vec<protobuf::PartitionId>> = Default::default();
 
-            info!(
-                "Cancelling {} running tasks for job {}",
-                running_tasks.len(),
-                job_id
-            );
-            for (partition, executor_id) in &running_tasks {
-                if let Some(parts) = tasks.get_mut(executor_id.as_str()) {
-                    parts.push(protobuf::PartitionId {
+        for (partition, executor_id) in &running_tasks {
+            if let Some(parts) = tasks.get_mut(executor_id.as_str()) {
+                parts.push(protobuf::PartitionId {
+                    job_id: job_id.to_owned(),
+                    stage_id: partition.stage_id as u32,
+                    partition_id: partition.partition_id as u32,
+                })
+            } else {
+                tasks.insert(
+                    executor_id.as_str(),
+                    vec![protobuf::PartitionId {
                         job_id: job_id.to_owned(),
                         stage_id: partition.stage_id as u32,
                         partition_id: partition.partition_id as u32,
-                    })
-                } else {
-                    tasks.insert(
-                        executor_id.as_str(),
-                        vec![protobuf::PartitionId {
-                            job_id: job_id.to_owned(),
-                            stage_id: partition.stage_id as u32,
-                            partition_id: partition.partition_id as u32,
-                        }],
-                    );
-                }
+                    }],
+                );
             }
-
-            for (executor_id, partitions) in tasks {
-                if let Ok(mut client) = executor_manager.get_client(executor_id).await {
-                    client
-                        .cancel_tasks(CancelTasksParams {
-                            partition_id: partitions,
-                        })
-                        .await?;
-                } else {
-                    error!("Failed to get client for executor ID {}", executor_id)
-                }
-            }
-            self.decrease_pending_queue_size(graph.available_tasks())?;
         }
+
+        for (executor_id, partitions) in tasks {
+            if let Ok(mut client) = executor_manager.get_client(executor_id).await {
+                client
+                    .cancel_tasks(CancelTasksParams {
+                        partition_id: partitions,
+                    })
+                    .await?;
+            } else {
+                error!("Failed to get client for executor ID {}", executor_id)
+            }
+        }
+
         Ok(())
     }
 
@@ -366,7 +364,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     pub async fn fail_running_job(&self, job_id: &str) -> Result<()> {
         if let Some(graph) = self.get_active_execution_graph(job_id).await {
             let graph = graph.read().await.clone();
-            let available_tasks = graph.available_tasks();
             let value = self.encode_execution_graph(graph)?;
 
             debug!("Moving job {} from Active to Failed", job_id);
@@ -375,7 +372,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             self.state
                 .put(Keyspace::FailedJobs, job_id.to_owned(), value)
                 .await?;
-            self.decrease_pending_queue_size(available_tasks)?
         } else {
             warn!("Fail to find job {} in the cache", job_id);
         }
@@ -389,13 +385,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             let mut graph = graph.write().await;
             graph.revive();
             let graph = graph.clone();
-            let available_tasks = graph.available_tasks();
             let value = self.encode_execution_graph(graph)?;
-
             self.state
                 .put(Keyspace::ActiveJobs, job_id.to_owned(), value)
                 .await?;
-            self.increase_pending_queue_size(available_tasks)?;
         } else {
             warn!("Fail to find job {} in the cache", job_id);
         }
@@ -580,35 +573,5 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .map(char::from)
             .take(7)
             .collect()
-    }
-
-    pub fn increase_pending_queue_size(&self, num: usize) -> Result<()> {
-        match self.pending_task_queue_size.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |s| Some(s + num),
-        ) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(BallistaError::Internal(
-                "Unable to update pending task counter".to_owned(),
-            )),
-        }
-    }
-
-    pub fn decrease_pending_queue_size(&self, num: usize) -> Result<()> {
-        match self.pending_task_queue_size.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |s| Some(s - num),
-        ) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(BallistaError::Internal(
-                "Unable to update pending task counter".to_owned(),
-            )),
-        }
-    }
-
-    pub fn get_pending_task_queue_size(&self) -> usize {
-        self.pending_task_queue_size.load(Ordering::SeqCst)
     }
 }


### PR DESCRIPTION
This is very hacky and completely untested but the basic setup should work I think. The hard part is managing the lifecycle of the accumulators since we don't really have a good way of removing them when they are no longer needed. I've hand-waved that problem away by just tossing them in an LRU cache so we at least don't leak memory in an unbounded way. 