### PR TITLE
broken pending queue size counter fix

### DIFF
--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -363,7 +363,7 @@ mod test {
         {
             let task = {
                 let mut graph = graph.write().await;
-                graph.pop_next_task("executor-1")?
+                graph.pop_next_task("executor-1")?.0
             };
             if let Some(task) = task {
                 let mut partitions: Vec<ShuffleWritePartition> = vec![];

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -183,11 +183,11 @@ impl ExecutionGraph {
             })
             .collect::<Vec<_>>();
 
-        let mut converted_tasks = 0usize;
+        let mut converted_tasks_number = 0usize;
 
         if !running_stages.is_empty() {
             for running_stage in running_stages {
-                converted_tasks += running_stage.available_tasks();
+                converted_tasks_number += running_stage.available_tasks();
 
                 self.stages.insert(
                     running_stage.stage_id,
@@ -195,7 +195,7 @@ impl ExecutionGraph {
                 );
             }
         }
-        converted_tasks
+        converted_tasks_number
     }
 
     /// Update task statuses and task metrics in the graph.
@@ -425,7 +425,7 @@ impl ExecutionGraph {
     /// available to the scheduler.
     /// If the task is not launched the status must be reset to allow the task to
     /// be scheduled elsewhere.
-    /// As a second element in the tuple we will return the number of converted stages during the task search
+    /// As a second element in the tuple we will return the number of converted tasks during the task search
     pub fn pop_next_task(&mut self, executor_id: &str) -> Result<(Option<Task>, usize)> {
         let job_id = self.job_id.clone();
         let session_id = self.session_id.clone();

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -474,10 +474,11 @@ impl ExecutionGraph {
         // If no available tasks found in the running stage,
         // try to find a resolved stage and convert it to the running stage
         if next_task.is_none() {
-            if self.revive() > 0 {
-                let (task, number_of_converted_tasks) =
-                    self.pop_next_task(executor_id)?;
-                number_of_converted_tasks_during_task_search = number_of_converted_tasks;
+            let number_of_converted_tasks_during_revive = self.revive();
+            if number_of_converted_tasks_during_revive > 0 {
+                let (task, _) = self.pop_next_task(executor_id)?;
+                number_of_converted_tasks_during_task_search =
+                    number_of_converted_tasks_during_revive;
                 next_task = task;
             } else {
                 next_task = None;

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -169,7 +169,7 @@ impl ExecutionGraph {
     }
 
     /// Revive the execution graph by converting the resolved stages to running stages
-    /// If any stages are converted, return amount of newly converted stages.
+    /// If any stages are converted, return amount of newly converted tasks.
     pub fn revive(&mut self) -> usize {
         let running_stages = self
             .stages

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -184,17 +184,15 @@ impl ExecutionGraph {
             .collect::<Vec<_>>();
         let running_stages_count = running_stages.len();
 
-        if running_stages.is_empty() {
-            0usize
-        } else {
+        if running_stages_count > 0 {
             for running_stage in running_stages {
                 self.stages.insert(
                     running_stage.stage_id,
                     ExecutionStage::Running(running_stage),
                 );
             }
-            running_stages_count
         }
+        running_stages_count
     }
 
     /// Update task statuses and task metrics in the graph.

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -322,7 +322,7 @@ impl ExecutionGraph {
         }
 
         match self.processing_stage_events(events)? {
-            Some(events) => Ok(Some((events, number_of_converted_tasks_during_revive))),
+            Some(events) => Ok(Some((events, self.available_tasks()))),
             _ => Ok(None),
         }
     }

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -195,6 +195,7 @@ impl ExecutionGraph {
                 );
             }
         }
+        info!("{} new tasks were found during revive", converted_tasks);
         converted_tasks
     }
 

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -323,7 +323,7 @@ impl ExecutionGraph {
         }
 
         match self.processing_stage_events(events)? {
-            Some(events) => Ok(Some((events, self.available_tasks()))),
+            Some(events) => Ok(Some((events, number_of_converted_tasks_during_revive))),
             _ => Ok(None),
         }
     }

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -195,7 +195,6 @@ impl ExecutionGraph {
                 );
             }
         }
-        info!("{} new tasks were found during revive", converted_tasks);
         converted_tasks
     }
 
@@ -476,6 +475,7 @@ impl ExecutionGraph {
         if next_task.is_none() {
             let number_of_converted_tasks_during_revive = self.revive();
             if number_of_converted_tasks_during_revive > 0 {
+                // we can ignore number of converted tasks from this call, as we revived everything in a previus revive call
                 let (task, _) = self.pop_next_task(executor_id)?;
                 number_of_converted_tasks_during_task_search =
                     number_of_converted_tasks_during_revive;

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -169,7 +169,7 @@ impl ExecutionGraph {
     }
 
     /// Revive the execution graph by converting the resolved stages to running stages
-    /// If any stages are converted, return amount of newly converted states.
+    /// If any stages are converted, return amount of newly converted stages.
     pub fn revive(&mut self) -> usize {
         let running_stages = self
             .stages

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -588,7 +588,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             Ordering::Relaxed,
             |s| Some(s + num),
         ) {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                info!("Pending queue size was incremented by: {}", num);
+                Ok(())
+            }
             Err(_) => Err(BallistaError::Internal(
                 "Unable to update pending task counter".to_owned(),
             )),
@@ -601,7 +604,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             Ordering::Relaxed,
             |s| Some(s - num),
         ) {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                info!("Pending queue size was decremented by: {}", num);
+                Ok(())
+            }
             Err(_) => Err(BallistaError::Internal(
                 "Unable to update pending task counter".to_owned(),
             )),

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -209,7 +209,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 if let Some(task) = graph.pop_next_task(&reservation.executor_id)? {
                     assignments.push((reservation.executor_id.clone(), task));
                     assign_tasks += 1;
-                    self.decrease_pending_queue_size(1)?;
                 } else {
                     break;
                 }
@@ -221,6 +220,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             }
         }
 
+        self.decrease_pending_queue_size(assign_tasks)?;
         let mut unassigned = vec![];
         for reservation in free_reservations.iter().skip(assign_tasks) {
             unassigned.push(reservation.clone());

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -217,6 +217,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                     // if during task retrieval we convert few tasks from scheduled to running stage,
                     // we need increase pending queue counter
                     if number_of_converted_tasks_during_task_search > 0 {
+                        info!(
+                            "{} new tasks were found during task search",
+                            number_of_converted_tasks_during_task_search
+                        );
                         self.increase_pending_queue_size(
                             number_of_converted_tasks_during_task_search,
                         )?;

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -220,7 +220,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             }
         }
 
-        self.decrease_pending_queue_size(assign_tasks)?;
+        if assign_tasks > 0 {
+            self.decrease_pending_queue_size(assign_tasks)?;
+        }
+
         let mut unassigned = vec![];
         for reservation in free_reservations.iter().skip(assign_tasks) {
             unassigned.push(reservation.clone());

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -583,6 +583,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     }
 
     pub fn increase_pending_queue_size(&self, num: usize) -> Result<()> {
+        info!("Increasing pending queue size by: {}", num);
         match self.pending_task_queue_size.fetch_update(
             Ordering::Relaxed,
             Ordering::Relaxed,
@@ -593,23 +594,24 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 Ok(())
             }
             Err(_) => Err(BallistaError::Internal(
-                "Unable to update pending task counter".to_owned(),
+                "Unable to increase pending queue size".to_owned(),
             )),
         }
     }
 
     pub fn decrease_pending_queue_size(&self, num: usize) -> Result<()> {
+        info!("Decreasing pending queue size by: {}", num);
         match self.pending_task_queue_size.fetch_update(
             Ordering::Relaxed,
             Ordering::Relaxed,
             |s| Some(s - num),
         ) {
             Ok(_) => {
-                info!("Pending queue size was decremented by: {}", num);
+                info!("Pending queue size was decreased by: {}", num);
                 Ok(())
             }
             Err(_) => Err(BallistaError::Internal(
-                "Unable to update pending task counter".to_owned(),
+                "Unable to decrease pending queue size".to_owned(),
             )),
         }
     }

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -167,9 +167,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 None
             };
 
-            if let Some((event, n)) = job_event {
+            if let Some((event, number_of_converted_tasks)) = job_event {
                 events.push(event);
-                self.increase_pending_queue_size(n)?;
+
+                if number_of_converted_tasks > 0 {
+                    self.increase_pending_queue_size(number_of_converted_tasks)?;
+                }
             }
         }
 

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -103,6 +103,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .await?;
 
         if graph.revive() {
+            info!("Available stages: {}", graph.stage_count());
             self.increase_pending_queue_size(graph.available_tasks())?;
         }
 

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -102,8 +102,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             )
             .await?;
 
-        if graph.revive() {
-            info!("Available stages: {}", graph.stage_count());
+        if graph.revive() > 0 {
             self.increase_pending_queue_size(graph.available_tasks())?;
         }
 
@@ -168,8 +167,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 None
             };
 
-            if let Some(event) = job_event {
+            if let Some((event, n)) = job_event {
                 events.push(event);
+                self.increase_pending_queue_size(n)?;
             }
         }
 
@@ -393,7 +393,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         if let Some(graph) = self.get_active_execution_graph(job_id).await {
             let mut graph = graph.write().await;
 
-            if graph.revive() {
+            if graph.revive() > 0 {
                 self.increase_pending_queue_size(graph.available_tasks())?;
             }
 


### PR DESCRIPTION
To correctly calculate the counter of pending tasks, we need to track the number of newly converted tasks from the `revive` method.

So right now we increasing pending queue size:
- submit new job
- revive
- update job

And decreasing it:
- filling reservation for task
- fail job
- cancel job