### PR TITLE
Expose pending queue size metric

### DIFF
--- a/ballista/rust/scheduler/src/scheduler_server/external_scaler.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/external_scaler.rs
@@ -57,7 +57,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExternalScaler
         Ok(Response::new(GetMetricsResponse {
             metric_values: vec![MetricValue {
                 metric_name: INFLIGHT_TASKS_METRIC_NAME.to_string(),
-                metric_value: 10000000, // A very high number to saturate the HPA
+                metric_value: self.state.task_manager.get_pending_task_queue_size()
+                    as i64,
             }],
         }))
     }

--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -363,7 +363,7 @@ mod test {
         {
             let task = {
                 let mut graph = graph.write().await;
-                graph.pop_next_task("executor-1")?
+                graph.pop_next_task("executor-1")?.0
             };
             if let Some(task) = task {
                 let mut partitions: Vec<ShuffleWritePartition> = vec![];

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -473,6 +473,7 @@ impl ExecutionGraph {
         if next_task.is_none() {
             let number_of_converted_tasks = self.revive();
             if number_of_converted_tasks > 0 {
+                // we can ignore num_of_conv tasks here, as we resolve them in previus step
                 let (task, _) = self.pop_next_task(executor_id)?;
                 next_task = task;
                 number_of_converted_tasks_during_search = number_of_converted_tasks;

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -320,10 +320,9 @@ impl ExecutionGraph {
             }
         }
 
-        match self.processing_stage_events(events)? {
-            Some(events) => Ok(Some((events, number_of_converted_tasks_during_revive))),
-            _ => Ok(None),
-        }
+        self.processing_stage_events(events).map(|maybe_evts| {
+            maybe_evts.map(|evts| (evts, number_of_converted_tasks_during_revive))
+        })
     }
 
     fn update_stage_output_links(

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -615,19 +615,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     }
     pub fn decrease_pending_queue_size(&self, num: usize) -> Result<()> {
         info!("Decreasing pending queue size by {}", num);
-        match self.pending_task_queue_size.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |s| Some(s - num),
-        ) {
-            Ok(_) => {
-                debug!("Pending queue size was decreased by: {}", num);
-                Ok(())
-            }
-            Err(_) => Err(BallistaError::Internal(
-                "Unable to decrease pending queue size".to_owned(),
-            )),
-        }
+       let result = self.pending_task_queue_size.fetch_sub(num, Ordering::Relaxed);
+
+        debug!("Pending queue size decreased by {} to {}", num, result);
+
+        Ok(())
     }
     pub fn get_pending_task_queue_size(&self) -> usize {
         self.pending_task_queue_size.load(Ordering::SeqCst)

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -157,6 +157,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         }
 
         let mut events: Vec<QueryStageSchedulerEvent> = vec![];
+        let mut number_of_converted_tasks = 0usize;
         for (job_id, statuses) in job_updates {
             let num_tasks = statuses.len();
             info!("Updating {} tasks in job {}", num_tasks, job_id);
@@ -171,13 +172,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 None
             };
 
-            if let Some((event, number_of_converted_tasks)) = job_event {
+            if let Some((event, num_of_conv_tasks)) = job_event {
                 events.push(event);
-
-                if number_of_converted_tasks > 0 {
-                    self.increase_pending_queue_size(number_of_converted_tasks);
-                }
+                number_of_converted_tasks += num_of_conv_tasks;
             }
+        }
+
+        if number_of_converted_tasks > 0 {
+            self.increase_pending_queue_size(number_of_converted_tasks);
         }
 
         Ok(events)

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -599,19 +599,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
     pub fn increase_pending_queue_size(&self, num: usize) -> Result<()> {
         info!("Increasing pending queue size by {}", num);
-        match self.pending_task_queue_size.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |s| Some(s + num),
-        ) {
-            Ok(_) => {
-                debug!("Pending queue size was increased by: {}", num);
-                Ok(())
-            }
-            Err(_) => Err(BallistaError::Internal(
-                "Unable to increase pending queue size".to_owned(),
-            )),
-        }
+        let result = self.pending_task_queue_size.fetch_add(num, Ordering::Relaxed);
+
+        debug!("Pending queue size increased by {} to {}", num, result);
+
+        Ok(())
     }
     pub fn decrease_pending_queue_size(&self, num: usize) -> Result<()> {
         info!("Decreasing pending queue size by {}", num);


### PR DESCRIPTION
To correctly calculate the counter of pending tasks, we need to track the number of newly converted tasks from the revive method.

So right now we increasing the pending queue size:
- submit new job
- revive
- update job

And decreasing it:
- filling reservation for task
- fail job
- cancel job