### PR TITLE
Introducing planning stage

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -808,12 +808,15 @@ message FailedJob {
   uint64 failed_at = 2;
 }
 
+message PlanningJob {}
+
 message JobStatus {
   oneof status {
     QueuedJob queued = 1;
     RunningJob running = 2;
     FailedJob failed = 3;
     CompletedJob completed = 4;
+    PlanningJob planning = 5;
   }
 }
 

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -307,12 +307,18 @@ async fn execute_query(
 
                 break Ok(futures::stream::iter(streams).flatten());
             }
-            _ => {
+            Some(job_status::Status::Planning(_)) => {
                 if has_status_change {
                     info!("Job {} still in initialization ...", job_id);
                 }
                 wait_future.await;
                 prev_status = status;
+            }
+            _ => {
+                break Err(DataFusionError::Execution(format!(
+                    "Status for job {} not found",
+                    job_id
+                )));
             }
         };
     }

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -278,13 +278,6 @@ async fn execute_query(
         let wait_future = tokio::time::sleep(Duration::from_millis(100));
         let has_status_change = prev_status != status;
         match status {
-            None => {
-                if has_status_change {
-                    info!("Job {} still in initialization ...", job_id);
-                }
-                wait_future.await;
-                prev_status = status;
-            }
             Some(job_status::Status::Queued(_)) => {
                 if has_status_change {
                     info!("Job {} still queued...", job_id);
@@ -313,6 +306,13 @@ async fn execute_query(
                 });
 
                 break Ok(futures::stream::iter(streams).flatten());
+            }
+            _ => {
+                if has_status_change {
+                    info!("Job {} still in initialization ...", job_id);
+                }
+                wait_future.await;
+                prev_status = status;
             }
         };
     }

--- a/ballista/rust/scheduler/scheduler_config_spec.toml
+++ b/ballista/rust/scheduler/scheduler_config_spec.toml
@@ -46,7 +46,6 @@ doc = "etcd urls for use when discovery mode is `etcd`. Default: localhost:2379"
 default = "std::string::String::from(\"localhost:2379\")"
 
 [[param]]
-abbr = "h"
 name = "bind_host"
 type = "String"
 default = "std::string::String::from(\"0.0.0.0\")"

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -462,19 +462,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             };
 
             let plan = match plan {
-                Ok(plan) => {
-                    self.state
-                        .task_manager
-                        .remove_job_from_planning(job_id.as_str())
-                        .await
-                        .map_err(|e| {
-                            let msg =
-                                format!("Error removing job from planning stage: {}", e);
-                            error!("{}", msg);
-                            Status::internal(msg)
-                        })?;
-                    plan
-                }
+                Ok(plan) => plan,
                 Err(e) => {
                     let failed_at = SystemTime::now()
                         .duration_since(UNIX_EPOCH)

--- a/ballista/rust/scheduler/src/state/backend/mod.rs
+++ b/ballista/rust/scheduler/src/state/backend/mod.rs
@@ -53,6 +53,7 @@ impl parse_arg::ParseArgFromStr for StateBackend {
 pub enum Keyspace {
     Executors,
     ActiveJobs,
+    PlanningJob,
     CompletedJobs,
     FailedJobs,
     Slots,


### PR DESCRIPTION
We have no way to indicate that the query is planning, in situations when query planning can take some time (bloom filter) we would like to respond with the job status `PlanningJob`