### PR TITLE
Serialize configoptions and pass them to executor

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -33,8 +33,8 @@ ballista = { path = "../ballista/client", version = "0.10.0", features = [
     "standalone",
 ] }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = "18.0.0"
-datafusion-cli = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion-cli = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 dirs = "4.0.0"
 env_logger = "0.10"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.63"
 ballista-core = { path = "../core", version = "0.10.0" }
 ballista-executor = { path = "../executor", version = "0.10.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.10.0", optional = true }
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -50,9 +50,9 @@ arrow-flight = { version = "32.0.0", features = ["flight-sql-experimental"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 datafusion-objectstore-hdfs = { version = "0.1.1", default-features = false, optional = true }
-datafusion-proto = "18.0.0"
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 futures = "0.3"
 hashbrown = "0.13"
 itertools = "0.10"

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -468,6 +468,7 @@ message MultiTaskDefinition {
 
 message SessionSettings {
   repeated KeyValuePair configs = 1;
+  repeated KeyValuePair extensions = 2;
 }
 
 message JobSessionConfig {

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -807,6 +807,8 @@ pub struct MultiTaskDefinition {
 pub struct SessionSettings {
     #[prost(message, repeated, tag = "1")]
     pub configs: ::prost::alloc::vec::Vec<KeyValuePair>,
+    #[prost(message, repeated, tag = "2")]
+    pub extensions: ::prost::alloc::vec::Vec<KeyValuePair>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.10.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -25,6 +25,7 @@ use std::{env, io};
 
 use anyhow::{Context, Result};
 use arrow_flight::flight_service_server::FlightServiceServer;
+use datafusion::config::Extensions;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use log::{error, info, warn};
@@ -281,6 +282,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
                     default_codec,
                     stop_send,
                     &shutdown_noti,
+                    Extensions::default(),
                 )
                 .await?,
             );
@@ -290,6 +292,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
                 scheduler.clone(),
                 executor.clone(),
                 default_codec,
+                Extensions::default(),
             )));
         }
     };

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -27,6 +27,7 @@ use ballista_core::{
     serde::protobuf::{scheduler_grpc_client::SchedulerGrpcClient, ExecutorRegistration},
     BALLISTA_VERSION,
 };
+use datafusion::config::Extensions;
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -95,6 +96,11 @@ pub async fn new_standalone_executor<
             )),
     );
 
-    tokio::spawn(execution_loop::poll_loop(scheduler, executor, codec));
+    tokio::spawn(execution_loop::poll_loop(
+        scheduler,
+        executor,
+        codec,
+        Extensions::default(),
+    ));
     Ok(())
 }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -51,8 +51,8 @@ base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 etcd-client = { version = "0.10", optional = true }
 flatbuffers = { version = "22.9.29" }
 futures = "0.3"

--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -36,6 +36,7 @@ use ballista_core::serde::protobuf::{
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use ballista_core::serde::BallistaCodec;
 use dashmap::DashMap;
+use datafusion::config::{ConfigOptions, Extensions};
 use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -66,6 +67,8 @@ pub struct KeyValueState<
     queued_jobs: DashMap<String, (String, u64)>,
     //// `SessionBuilder` for constructing `SessionContext` from stored `BallistaConfig`
     session_builder: SessionBuilder,
+    /// Default datafusion config extensions
+    default_extensions: Extensions,
 }
 
 impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
@@ -76,6 +79,7 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         store: S,
         codec: BallistaCodec<T, U>,
         session_builder: SessionBuilder,
+        default_extensions: Extensions,
     ) -> Self {
         Self {
             store,
@@ -83,6 +87,7 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             codec,
             queued_jobs: DashMap::new(),
             session_builder,
+            default_extensions,
         }
     }
 }
@@ -632,12 +637,24 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         }
         let config = config_builder.build()?;
 
-        Ok(create_datafusion_context(&config, self.session_builder))
+        let mut extensions = ConfigOptions::default();
+        extensions.extensions = self.default_extensions.clone();
+        for kv_pair in &settings.extensions {
+            extensions.set(&kv_pair.key, &kv_pair.value)?;
+        }
+
+        Ok(create_datafusion_context(
+            Some(session_id.to_string()),
+            &config,
+            extensions.extensions,
+            self.session_builder,
+        ))
     }
 
     async fn create_session(
         &self,
         config: &BallistaConfig,
+        extensions: Extensions,
     ) -> Result<Arc<SessionContext>> {
         let mut settings: Vec<KeyValuePair> = vec![];
 
@@ -648,9 +665,26 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             })
         }
 
-        let value = protobuf::SessionSettings { configs: settings };
+        let session =
+            create_datafusion_context(None, config, extensions, self.session_builder);
 
-        let session = create_datafusion_context(config, self.session_builder);
+        let extensions = session
+            .state()
+            .config_options()
+            .entries()
+            .iter()
+            .filter_map(|config| {
+                config.value.as_ref().map(|value| KeyValuePair {
+                    key: config.key.clone(),
+                    value: value.clone(),
+                })
+            })
+            .collect();
+
+        let value = protobuf::SessionSettings {
+            configs: settings,
+            extensions,
+        };
 
         self.store
             .put(
@@ -667,6 +701,7 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         &self,
         session_id: &str,
         config: &BallistaConfig,
+        extensions: Extensions,
     ) -> Result<Arc<SessionContext>> {
         let mut settings: Vec<KeyValuePair> = vec![];
 
@@ -677,7 +712,31 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             })
         }
 
-        let value = protobuf::SessionSettings { configs: settings };
+        let session = create_datafusion_context(
+            Some(session_id.to_string()),
+            config,
+            extensions,
+            self.session_builder,
+        );
+
+        let extensions = session
+            .state()
+            .config_options()
+            .entries()
+            .iter()
+            .filter_map(|config| {
+                config.value.as_ref().map(|value| KeyValuePair {
+                    key: config.key.clone(),
+                    value: value.clone(),
+                })
+            })
+            .collect();
+
+        let value = protobuf::SessionSettings {
+            configs: settings,
+            extensions,
+        };
+
         self.store
             .put(
                 Keyspace::Sessions,
@@ -686,7 +745,7 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             )
             .await?;
 
-        Ok(create_datafusion_context(config, self.session_builder))
+        Ok(session)
     }
 }
 
@@ -714,11 +773,14 @@ mod test {
 
     #[cfg(feature = "sled")]
     fn make_sled_state() -> Result<KeyValueState<SledClient>> {
+        use datafusion::config::Extensions;
+
         Ok(KeyValueState::new(
             "",
             SledClient::try_new_temporary()?,
             BallistaCodec::default(),
             default_session_builder,
+            Extensions::default(),
         ))
     }
 

--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -637,8 +637,8 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         }
         let config = config_builder.build()?;
 
-        let mut extensions = ConfigOptions::default();
-        extensions.extensions = self.default_extensions.clone();
+        let mut extensions =
+            ConfigOptions::with_extensions(self.default_extensions.clone());
         for kv_pair in &settings.extensions {
             extensions.set(&kv_pair.key, &kv_pair.value)?;
         }

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -30,6 +30,7 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use dashmap::DashMap;
+use datafusion::config::Extensions;
 use datafusion::prelude::SessionContext;
 
 use crate::cluster::event::ClusterEventSender;
@@ -413,8 +414,10 @@ impl JobState for InMemoryJobState {
     async fn create_session(
         &self,
         config: &BallistaConfig,
+        extensions: Extensions,
     ) -> Result<Arc<SessionContext>> {
-        let session = create_datafusion_context(config, self.session_builder);
+        let session =
+            create_datafusion_context(None, config, extensions, self.session_builder);
         self.sessions.insert(session.session_id(), session.clone());
 
         Ok(session)
@@ -424,8 +427,14 @@ impl JobState for InMemoryJobState {
         &self,
         session_id: &str,
         config: &BallistaConfig,
+        extensions: Extensions,
     ) -> Result<Arc<SessionContext>> {
-        let session = create_datafusion_context(config, self.session_builder);
+        let session = create_datafusion_context(
+            Some(session_id.to_string()),
+            config,
+            extensions,
+            self.session_builder,
+        );
         self.sessions
             .insert(session_id.to_string(), session.clone());
 

--- a/ballista/scheduler/src/flight_sql.rs
+++ b/ballista/scheduler/src/flight_sql.rs
@@ -30,6 +30,7 @@ use arrow_flight::{
     Action, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
     HandshakeResponse, Location, Ticket,
 };
+use datafusion::config::Extensions;
 use log::{debug, error, warn};
 use std::convert::TryFrom;
 use std::pin::Pin;
@@ -136,7 +137,7 @@ impl FlightSqlServiceImpl {
             .server
             .state
             .session_manager
-            .create_session(&config)
+            .create_session(&config, Extensions::default())
             .await
             .map_err(|e| {
                 Status::internal(format!("Failed to create SessionContext: {e:?}"))

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -38,6 +38,7 @@ use crate::state::executor_manager::{
     ExecutorManager, ExecutorReservation, DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
     EXPIRE_DEAD_EXECUTOR_INTERVAL_SECS,
 };
+use crate::state::session_manager::SessionManager;
 use crate::state::task_manager::TaskLauncher;
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use log::{error, warn};
@@ -376,6 +377,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             .executor_manager
             .get_alive_executors_within_one_minute()
     }
+
+    pub fn session_manager(&self) -> SessionManager {
+        self.state.session_manager.clone()
+    }
 }
 
 pub fn timestamp_secs() -> u64 {
@@ -397,6 +402,7 @@ mod test {
     use std::sync::Arc;
 
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::config::Extensions;
     use datafusion::logical_expr::{col, sum, LogicalPlan};
 
     use datafusion::test_util::scan_empty;
@@ -449,7 +455,7 @@ mod test {
         let ctx = scheduler
             .state
             .session_manager
-            .create_session(&config)
+            .create_session(&config, Extensions::default())
             .await?;
 
         let job_id = "job";

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -25,6 +25,7 @@ use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
 };
+use datafusion::config::Extensions;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use log::info;
@@ -39,6 +40,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
         "localhost:50050",
         default_session_builder,
         BallistaCodec::default(),
+        Extensions::default(),
     );
 
     let mut scheduler_server: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -429,6 +429,7 @@ mod test {
         ExecutorData, ExecutorMetadata, ExecutorSpecification,
     };
     use ballista_core::serde::BallistaCodec;
+    use datafusion::config::Extensions;
 
     use crate::config::SchedulerConfig;
 
@@ -492,7 +493,10 @@ mod test {
                 Arc::new(BlackholeTaskLauncher::default()),
             ));
 
-        let session_ctx = state.session_manager.create_session(&config).await?;
+        let session_ctx = state
+            .session_manager
+            .create_session(&config, Extensions::default())
+            .await?;
 
         let plan = test_graph(session_ctx.clone()).await;
 
@@ -592,7 +596,10 @@ mod test {
                 Arc::new(BlackholeTaskLauncher::default()),
             ));
 
-        let session_ctx = state.session_manager.create_session(&config).await?;
+        let session_ctx = state
+            .session_manager
+            .create_session(&config, Extensions::default())
+            .await?;
 
         let plan = test_graph(session_ctx.clone()).await;
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use ballista_core::error::{BallistaError, Result};
+use datafusion::config::Extensions;
 use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
@@ -478,7 +479,7 @@ impl SchedulerTest {
         self.scheduler
             .state
             .session_manager
-            .create_session(&self.ballista_config)
+            .create_session(&self.ballista_config, Extensions::default())
             .await
     }
 
@@ -493,7 +494,7 @@ impl SchedulerTest {
             .scheduler
             .state
             .session_manager
-            .create_session(&self.ballista_config)
+            .create_session(&self.ballista_config, Extensions::default())
             .await?;
 
         self.scheduler
@@ -618,7 +619,7 @@ impl SchedulerTest {
             .scheduler
             .state
             .session_manager
-            .create_session(&self.ballista_config)
+            .create_session(&self.ballista_config, Extensions::default())
             .await?;
 
         self.scheduler

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,8 +34,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 env_logger = "0.10"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = "18.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"


### PR DESCRIPTION
- add serialization of configoptions
- pass them to executors
- reconstruct configoptions on executors
- requires https://github.com/coralogix/arrow-datafusion/tree/allow-extensions-in-taskcontext