### PR TITLE
Remove cancelled jobs from active cache

### DIFF
--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1232,6 +1232,7 @@ impl ExecutionGraph {
 
     /// fail job with error message
     pub fn fail_job(&mut self, error: String) {
+        self.end_time = timestamp_millis();
         self.status = JobStatus {
             job_id: self.job_id.clone(),
             job_name: self.job_name.clone(),
@@ -1259,6 +1260,7 @@ impl ExecutionGraph {
             .map(|l| l.try_into())
             .collect::<Result<Vec<_>>>()?;
 
+        self.end_time = timestamp_millis();
         self.status = JobStatus {
             job_id: self.job_id.clone(),
             job_name: self.job_name.clone(),
@@ -1270,10 +1272,6 @@ impl ExecutionGraph {
                 ended_at: self.end_time,
             })),
         };
-        self.end_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
 
         Ok(())
     }

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -47,6 +47,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
+use crate::scheduler_server::timestamp_millis;
 use tracing::trace;
 
 type ActiveJobCache = Arc<DashMap<String, JobInfoCache>>;
@@ -417,6 +418,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
             self.state.save_job(job_id, &guard).await?;
 
+            // After state is saved, remove job from active cache
+            let _ = self.remove_active_execution_graph(job_id);
+
             (running_tasks, pending_tasks)
         } else {
             // TODO listen the job state update event and fix task cancelling
@@ -536,10 +540,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 plan,
                 output_partitioning,
                 session_id: task.session_id,
-                launch_time: SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64,
+                launch_time: timestamp_millis(),
                 props: vec![],
             };
             Ok(task_definition)


### PR DESCRIPTION
[sc-16524]

We were not removing cancelled jobs from the active cache which was causing warnings in the log and also a memory leak 