### PR TITLE
update datafusion tag

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -33,8 +33,8 @@ ballista = { path = "../ballista/client", version = "0.10.0", features = [
     "standalone",
 ] }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
-datafusion-cli = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
+datafusion-cli = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 dirs = "4.0.0"
 env_logger = "0.10"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.63"
 ballista-core = { path = "../core", version = "0.10.0" }
 ballista-executor = { path = "../executor", version = "0.10.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.10.0", optional = true }
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
-datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -50,9 +50,9 @@ arrow-flight = { version = "32.0.0", features = ["flight-sql-experimental"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 datafusion-objectstore-hdfs = { version = "0.1.1", default-features = false, optional = true }
-datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 futures = "0.3"
 hashbrown = "0.13"
 itertools = "0.10"

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.10.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
-datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -51,8 +51,8 @@ base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
-datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 etcd-client = { version = "0.10", optional = true }
 flatbuffers = { version = "22.9.29" }
 futures = "0.3"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,8 +34,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
-datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 env_logger = "0.10"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", branch = "allow-extensions-in-taskcontext" }
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v18.0.0-cx.1" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"


### PR DESCRIPTION
It seems that I can not patch datafusion in dqe correct tag when our ballista fork already uses our datafusion fork.