### PR TITLE
[DRAFT] Fair scheduling

### DIFF
--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -50,6 +50,7 @@ ballista-core = { path = "../core", version = "0.11.0", features = ["s3"] }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
+crossbeam-queue = "0.3.8"
 dashmap = "5.4.0"
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }

--- a/ballista/scheduler/scheduler_config_spec.toml
+++ b/ballista/scheduler/scheduler_config_spec.toml
@@ -137,10 +137,10 @@ doc = "Tracing log rotation policy, possible values: minutely, hourly, daily, ne
 default = "ballista_core::config::LogRotationPolicy::Daily"
 
 [[param]]
-name = "job_resubmit_interval_ms"
+name = "scheduler_tick_interval_ms"
 type = "u64"
-default = "0"
-doc = "If job is not able to be scheduled on submission, wait for this interval and resubmit. Default value of 0 indicates that job shuuld not be resubmitted"
+default = "500"
+doc = "If the scheduler cannot scheduler pending tasks due to lack of available resources, it will attempt again after (approximately) this interval in milliseconds. Default of 500ms"
 
 [[param]]
 name = "executor_termination_grace_period"

--- a/ballista/scheduler/scheduler_config_spec.toml
+++ b/ballista/scheduler/scheduler_config_spec.toml
@@ -143,6 +143,13 @@ default = "500"
 doc = "If the scheduler cannot scheduler pending tasks due to lack of available resources, it will attempt again after (approximately) this interval in milliseconds. Default of 500ms"
 
 [[param]]
+name = "tasks_per_tick"
+type = "u64"
+default = "256"
+doc = "The maximum number of tasks that can be scheduled on each scheduler tick"
+
+
+[[param]]
 name = "executor_termination_grace_period"
 type = "u64"
 default = "30"

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -116,8 +116,7 @@ async fn main() -> Result<()> {
             .finished_job_state_clean_up_interval_seconds,
         advertise_flight_sql_endpoint: opt.advertise_flight_sql_endpoint,
         cluster_storage: ClusterStorageConfig::Memory,
-        job_resubmit_interval_ms: (opt.job_resubmit_interval_ms > 0)
-            .then_some(opt.job_resubmit_interval_ms),
+        scheduler_tick_interval_ms: opt.scheduler_tick_interval_ms,
         executor_termination_grace_period: opt.executor_termination_grace_period,
     };
 

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -117,6 +117,7 @@ async fn main() -> Result<()> {
         advertise_flight_sql_endpoint: opt.advertise_flight_sql_endpoint,
         cluster_storage: ClusterStorageConfig::Memory,
         scheduler_tick_interval_ms: opt.scheduler_tick_interval_ms,
+        tasks_per_tick: opt.tasks_per_tick,
         executor_termination_grace_period: opt.executor_termination_grace_period,
     };
 

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -44,9 +44,9 @@ pub struct SchedulerConfig {
     pub finished_job_state_clean_up_interval_seconds: u64,
     /// The route endpoint for proxying flight sql results via scheduler
     pub advertise_flight_sql_endpoint: Option<String>,
-    /// If provided, submitted jobs which do not have tasks scheduled will be resubmitted after `job_resubmit_interval_ms`
-    /// milliseconds
-    pub job_resubmit_interval_ms: Option<u64>,
+    /// When the scheduler cannot complete a scheduling task due to lack of resources it will wait for this amount of time
+    /// (in milliseconds) to reschedule an action.
+    pub scheduler_tick_interval_ms: u64,
     /// Configuration for ballista cluster storage
     pub cluster_storage: ClusterStorageConfig,
     /// Time in seconds to allow executor for graceful shutdown. Once an executor signals it has entered Terminating status
@@ -67,7 +67,7 @@ impl Default for SchedulerConfig {
             finished_job_state_clean_up_interval_seconds: 3600,
             advertise_flight_sql_endpoint: None,
             cluster_storage: ClusterStorageConfig::Memory,
-            job_resubmit_interval_ms: None,
+            scheduler_tick_interval_ms: 500,
             executor_termination_grace_period: 0,
         }
     }
@@ -141,8 +141,8 @@ impl SchedulerConfig {
         self
     }
 
-    pub fn with_job_resubmit_interval_ms(mut self, interval_ms: u64) -> Self {
-        self.job_resubmit_interval_ms = Some(interval_ms);
+    pub fn with_scheduler_tick_interval_ms(mut self, interval_ms: u64) -> Self {
+        self.scheduler_tick_interval_ms = interval_ms;
         self
     }
 

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -47,6 +47,8 @@ pub struct SchedulerConfig {
     /// When the scheduler cannot complete a scheduling task due to lack of resources it will wait for this amount of time
     /// (in milliseconds) to reschedule an action.
     pub scheduler_tick_interval_ms: u64,
+    /// Number of tasks that can be scheduler on each scheduler tick
+    pub tasks_per_tick: u64,
     /// Configuration for ballista cluster storage
     pub cluster_storage: ClusterStorageConfig,
     /// Time in seconds to allow executor for graceful shutdown. Once an executor signals it has entered Terminating status
@@ -68,6 +70,7 @@ impl Default for SchedulerConfig {
             advertise_flight_sql_endpoint: None,
             cluster_storage: ClusterStorageConfig::Memory,
             scheduler_tick_interval_ms: 500,
+            tasks_per_tick: 256,
             executor_termination_grace_period: 0,
         }
     }
@@ -143,6 +146,11 @@ impl SchedulerConfig {
 
     pub fn with_scheduler_tick_interval_ms(mut self, interval_ms: u64) -> Self {
         self.scheduler_tick_interval_ms = interval_ms;
+        self
+    }
+
+    pub fn with_tasks_per_tick(mut self, value: u64) -> Self {
+        self.tasks_per_tick = value;
         self
     }
 

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::state::executor_manager::ExecutorReservation;
+use std::fmt::{Debug, Formatter};
 
 use datafusion::logical_expr::LogicalPlan;
 
@@ -65,4 +66,31 @@ pub enum QueryStageSchedulerEvent {
     ReservationOffering(Vec<ExecutorReservation>),
     ExecutorLost(String, Option<String>),
     CancelTasks(Vec<RunningTaskInfo>),
+    Tick,
+}
+
+impl Debug for QueryStageSchedulerEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryStageSchedulerEvent::JobQueued { .. } => write!(f, "JobQueued"),
+            QueryStageSchedulerEvent::JobSubmitted { .. } => write!(f, "JobSubmitted"),
+            QueryStageSchedulerEvent::JobPlanningFailed { .. } => {
+                write!(f, "JobPlanningFailed")
+            }
+            QueryStageSchedulerEvent::JobFinished { .. } => write!(f, "JobFinished"),
+            QueryStageSchedulerEvent::JobRunningFailed { .. } => {
+                write!(f, "JobRunningFailed")
+            }
+            QueryStageSchedulerEvent::JobUpdated(_) => write!(f, "JobUpdated"),
+            QueryStageSchedulerEvent::JobCancel(_) => write!(f, "JobCancel"),
+            QueryStageSchedulerEvent::JobDataClean(_) => write!(f, "JobDataClean"),
+            QueryStageSchedulerEvent::TaskUpdating(_, _) => write!(f, "TaskUpdating"),
+            QueryStageSchedulerEvent::ReservationOffering(_) => {
+                write!(f, "ReservationOffering")
+            }
+            QueryStageSchedulerEvent::ExecutorLost(_, _) => write!(f, "ExecutorLost"),
+            QueryStageSchedulerEvent::CancelTasks(_) => write!(f, "CancelTasks"),
+            QueryStageSchedulerEvent::Tick => write!(f, "Tick"),
+        }
+    }
 }

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -88,7 +88,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         let query_stage_scheduler = Arc::new(QueryStageScheduler::new(
             state.clone(),
             metrics_collector,
-            config.job_resubmit_interval_ms,
+            config.scheduler_tick_interval_ms,
         ));
         let query_stage_event_loop = EventLoop::new(
             "query_stage".to_owned(),
@@ -125,7 +125,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         let query_stage_scheduler = Arc::new(QueryStageScheduler::new(
             state.clone(),
             metrics_collector,
-            config.job_resubmit_interval_ms,
+            config.scheduler_tick_interval_ms,
         ));
         let query_stage_event_loop = EventLoop::new(
             "query_stage".to_owned(),

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -89,6 +89,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             state.clone(),
             metrics_collector,
             config.scheduler_tick_interval_ms,
+            config.tasks_per_tick as usize,
         ));
         let query_stage_event_loop = EventLoop::new(
             "query_stage".to_owned(),
@@ -126,6 +127,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             state.clone(),
             metrics_collector,
             config.scheduler_tick_interval_ms,
+            config.tasks_per_tick as usize,
         ));
         let query_stage_event_loop = EventLoop::new(
             "query_stage".to_owned(),

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use log::{debug, error, info};
+use tracing::{debug, error, info};
 
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::event_loop::{EventAction, EventSender};
@@ -33,10 +33,9 @@ use tokio::sync::mpsc;
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 
-use crate::state::executor_manager::ExecutorReservation;
 use crate::state::SchedulerState;
 
-const MAX_TASKS_PER_TICK: usize = 96;
+const MAX_TASKS_PER_TICK: usize = 144;
 
 pub(crate) struct QueryStageScheduler<
     T: 'static + AsLogicalPlan,
@@ -45,31 +44,31 @@ pub(crate) struct QueryStageScheduler<
     state: Arc<SchedulerState<T, U>>,
     metrics_collector: Arc<dyn SchedulerMetricsCollector>,
     pending_tasks: AtomicUsize,
-    job_resubmit_interval_ms: Option<u64>,
+    tick_interval: u64,
 }
 
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageScheduler<T, U> {
     pub(crate) fn new(
         state: Arc<SchedulerState<T, U>>,
         metrics_collector: Arc<dyn SchedulerMetricsCollector>,
-        job_resubmit_interval_ms: Option<u64>,
+        tick_interval: u64,
     ) -> Self {
         Self {
             state,
             metrics_collector,
             pending_tasks: AtomicUsize::default(),
-            job_resubmit_interval_ms,
+            tick_interval,
         }
     }
 
     pub(crate) fn set_pending_tasks(&self, tasks: usize) {
-        self.pending_tasks.store(tasks, Ordering::SeqCst);
+        self.pending_tasks.store(tasks, Ordering::Release);
         self.metrics_collector
             .set_pending_tasks_queue_size(tasks as u64);
     }
 
     pub(crate) fn pending_tasks(&self) -> usize {
-        self.pending_tasks.load(Ordering::SeqCst)
+        self.pending_tasks.load(Ordering::Acquire)
     }
 
     pub(crate) fn metrics_collector(&self) -> &dyn SchedulerMetricsCollector {
@@ -133,6 +132,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                             resubmit: false,
                         }
                     };
+
                     if let Err(e) = tx_event.post_event(event).await {
                         error!("Fail to send event due to {}", e);
                     }
@@ -151,63 +151,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                         submitted_at,
                     );
 
-                    info!("Job {} submitted", job_id);
+                    info!(job_id, "job submitted");
                 } else {
-                    debug!("Job {} resubmitted", job_id);
+                    debug!(job_id, "job resubmitted");
                 }
 
                 if self.state.config.is_push_staged_scheduling() {
-                    let available_tasks = self
-                        .state
-                        .task_manager
-                        .get_available_task_count(&job_id)
-                        .await?;
-
-                    let reservations: Vec<ExecutorReservation> = self
-                        .state
-                        .executor_manager
-                        .reserve_slots(available_tasks as u32)
-                        .await?
-                        .into_iter()
-                        .map(|res| res.assign(job_id.clone()))
-                        .collect();
-
-                    if reservations.is_empty() && self.job_resubmit_interval_ms.is_some()
-                    {
-                        let wait_ms = self.job_resubmit_interval_ms.unwrap();
-
-                        debug!(
-                            "No task slots reserved for job {job_id}, resubmitting after {wait_ms}ms"
-                        );
-
-                        tokio::task::spawn(async move {
-                            tokio::time::sleep(Duration::from_millis(wait_ms)).await;
-
-                            if let Err(e) = tx_event
-                                .post_event(QueryStageSchedulerEvent::JobSubmitted {
-                                    job_id,
-                                    queued_at,
-                                    submitted_at,
-                                    resubmit: true,
-                                })
-                                .await
-                            {
-                                error!("error resubmitting job: {}", e);
-                            }
-                        });
-                    } else {
-                        debug!(
-                            "Reserved {} task slots for submitted job {}",
-                            reservations.len(),
-                            job_id
-                        );
-
-                        tx_event
-                            .post_event(QueryStageSchedulerEvent::ReservationOffering(
-                                reservations,
-                            ))
-                            .await?;
-                    }
+                    // submit a scheduler tick.
+                    tx_event.post_event(QueryStageSchedulerEvent::Tick).await?;
                 }
             }
             QueryStageSchedulerEvent::JobPlanningFailed {
@@ -261,13 +212,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 self.state.clean_up_failed_job(job_id);
             }
             QueryStageSchedulerEvent::JobUpdated(job_id) => {
-                info!("Job {} Updated", job_id);
+                info!(job_id, "job updated");
                 self.state.task_manager.update_job(&job_id).await?;
             }
             QueryStageSchedulerEvent::JobCancel(job_id) => {
                 self.metrics_collector.record_cancelled(&job_id);
 
-                info!("Job {} Cancelled", job_id);
+                info!(job_id, "job cancelled");
                 let (running_tasks, _pending_tasks) =
                     self.state.task_manager.cancel_job(&job_id).await?;
                 self.state.clean_up_failed_job(job_id);
@@ -278,6 +229,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             }
             QueryStageSchedulerEvent::TaskUpdating(executor_id, tasks_status) => {
                 debug!(
+                    executor_id,
                     "processing task status updates from {executor_id}: {:?}",
                     tasks_status
                 );
@@ -310,16 +262,24 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                     }
                 }
             }
-            QueryStageSchedulerEvent::ReservationOffering(reservations) => {
-                let (reservations, pending) =
+            QueryStageSchedulerEvent::ReservationOffering(mut reservations) => {
+                let mut remainder = if reservations.len() > MAX_TASKS_PER_TICK {
+                    reservations.split_off(MAX_TASKS_PER_TICK)
+                } else {
+                    vec![]
+                };
+
+                let (reservations, _) =
                     self.state.offer_reservation(reservations).await?;
 
-                self.set_pending_tasks(pending);
+                self.set_pending_tasks(self.state.task_manager.get_pending_task_count());
 
-                if !reservations.is_empty() {
+                remainder.extend(reservations);
+
+                if !remainder.is_empty() {
                     tx_event
                         .post_event(QueryStageSchedulerEvent::ReservationOffering(
-                            reservations,
+                            remainder,
                         ))
                         .await?;
                 }
@@ -337,7 +297,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                         let msg = format!(
                             "TaskManager error to handle Executor {executor_id} lost: {e}"
                         );
-                        error!("{}", msg);
+                        error!(executor_id, "{msg}");
                     }
                 }
             }
@@ -349,6 +309,47 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             }
             QueryStageSchedulerEvent::JobDataClean(job_id) => {
                 self.state.executor_manager.clean_up_job_data(job_id);
+            }
+            QueryStageSchedulerEvent::Tick => {
+                let pending_tasks = self.state.task_manager.get_pending_task_count();
+
+                self.set_pending_tasks(pending_tasks);
+
+                if pending_tasks > 0 {
+                    let num_tasks = pending_tasks.min(MAX_TASKS_PER_TICK);
+
+                    let reservations = self
+                        .state
+                        .executor_manager
+                        .reserve_slots(num_tasks as u32)
+                        .await?;
+
+                    let num_reservations = reservations.len();
+
+                    if !reservations.is_empty() {
+                        tx_event
+                            .post_event(QueryStageSchedulerEvent::ReservationOffering(
+                                reservations,
+                            ))
+                            .await?;
+                    }
+
+                    if pending_tasks > MAX_TASKS_PER_TICK || num_reservations < num_tasks
+                    {
+                        // if there are more available tasks or we are not able to reserve all of
+                        // our slots, scheduler another tick
+                        let interval = self.tick_interval;
+                        tokio::task::spawn(async move {
+                            tokio::time::sleep(Duration::from_millis(interval)).await;
+
+                            if let Err(e) =
+                                tx_event.post_event(QueryStageSchedulerEvent::Tick).await
+                            {
+                                error!(error = ?e, "error sending tick");
+                            }
+                        });
+                    }
+                }
             }
         }
 
@@ -375,16 +376,17 @@ mod tests {
     use std::time::Duration;
     use tracing_subscriber::EnvFilter;
 
+    #[ignore]
     #[tokio::test]
     async fn test_job_resubmit() -> Result<()> {
         let plan = test_plan(10);
 
         let metrics_collector = Arc::new(TestMetricsCollector::default());
 
-        // Set resubmit interval of 1ms
+        // Set resubmit interval of 50ms
         let mut test = SchedulerTest::new(
             SchedulerConfig::default()
-                .with_job_resubmit_interval_ms(1)
+                .with_scheduler_tick_interval_ms(50)
                 .with_scheduler_policy(TaskSchedulingPolicy::PushStaged),
             metrics_collector.clone(),
             0,
@@ -410,10 +412,15 @@ mod tests {
 
         let next_event = rx.recv().await.unwrap();
 
-        assert!(matches!(
-            next_event,
-            QueryStageSchedulerEvent::JobSubmitted { job_id, resubmit, .. } if job_id == "job-id" && resubmit
-        ));
+        println!("receieved {next_event:?}");
+
+        assert!(matches!(next_event, QueryStageSchedulerEvent::Tick));
+
+        let next_event = rx.recv().await.unwrap();
+
+        println!("receieved {next_event:?}");
+
+        assert!(matches!(next_event, QueryStageSchedulerEvent::Tick));
 
         Ok(())
     }

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -36,6 +36,8 @@ use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::state::executor_manager::ExecutorReservation;
 use crate::state::SchedulerState;
 
+const MAX_TASKS_PER_TICK: usize = 96;
+
 pub(crate) struct QueryStageScheduler<
     T: 'static + AsLogicalPlan,
     U: 'static + AsExecutionPlan,


### PR DESCRIPTION
Try and implement a fairer scheduling algorithm:

1. In `TaskManager` create an explicit queue for jobs so jobs are scheduled in FIFO order. This is done on a "per-tick" basis. So each time there are a batch of task slots to fill, the scheduler will pop the job on the front of the queue and scheduler tasks for it. That job will then go on the back of the queue. So if a very large job is in the queue it cannot starve other smaller jobs of resources. 
2. Limit the number of tasks that are allocated in each scheduler "tick". This is currently hardcoded but will need to be made configurable. 

Still need to test this out so leaving it as a draft for now