### PR TITLE
Do not fail task update when metrics array has wrong length

### DIFF
--- a/ballista/scheduler/src/display.rs
+++ b/ballista/scheduler/src/display.rs
@@ -25,8 +25,8 @@ use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::{
     accept, DisplayFormatType, ExecutionPlan, ExecutionPlanVisitor,
 };
-use log::{error, info};
 use std::fmt;
+use tracing::{info, warn};
 
 pub fn print_stage_metrics(
     job_id: &str,
@@ -47,14 +47,14 @@ pub fn print_stage_metrics(
         );
 
         info!(
-            "=== [{}/{}] Stage finished, physical plan with metrics ===\n{}\n",
             job_id,
             stage_id,
+            "=== Stage finished, physical plan with metrics ===\n{}\n",
             DisplayableBallistaExecutionPlan::new(plan, &plan_metrics).indent()
         );
     } else {
-        error!("Fail to combine stage metrics to plan for stage [{}/{}],  plan metrics array size {} does not equal
-                to the stage metrics array size {}", job_id, stage_id, plan_metrics.len(), stage_metrics.len());
+        warn!(job_id, stage_id, "Fail to combine stage metrics to plan,  plan metrics array size {} does not equal
+                to the stage metrics array size {}", plan_metrics.len(), stage_metrics.len());
     }
 }
 

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -28,7 +28,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::execution_plans::{ShuffleWriterExec, UnresolvedShuffleExec};
@@ -454,8 +454,12 @@ impl ExecutionGraph {
                                 successful_task,
                             )) = task_status.status
                             {
-                                // update task metrics for successfu task
-                                running_stage.update_task_metrics(operator_metrics)?;
+                                // update task metrics for successful task
+                                if let Err(err) =
+                                    running_stage.update_task_metrics(operator_metrics)
+                                {
+                                    error!(job_id = self.job_id, stage_id = running_stage.stage_id, error = %err, "Error updating task metrics");
+                                }
 
                                 locations.append(&mut partition_to_location(
                                     &job_id,

--- a/ballista/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_graph/execution_stage.rs
@@ -28,7 +28,7 @@ use datafusion::physical_plan::metrics::{MetricValue, MetricsSet};
 use datafusion::physical_plan::{ExecutionPlan, Metric, Partitioning};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_proto::logical_plan::AsLogicalPlan;
-use log::{debug, warn};
+use tracing::{debug, warn};
 
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::protobuf::failed_task::FailedReason;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
