### PR TITLE
Additional scheduler metrics

### DIFF
--- a/ballista/scheduler/src/metrics/mod.rs
+++ b/ballista/scheduler/src/metrics/mod.rs
@@ -47,6 +47,12 @@ pub trait SchedulerMetricsCollector: Send + Sync {
     /// Record that job with `job_id` was cancelled.
     fn record_cancelled(&self, job_id: &str);
 
+    /// Record that an event of type `event_type` was processed in `processing_time_ms`
+    fn record_process_event(&self, event_type: &str, processing_time_ms: u64);
+
+    /// Record that an event of type `event_type` encountered an error during processing
+    fn record_event_failed(&self, event_type: &str);
+
     /// Set the current number of pending tasks in scheduler. A pending task is a task that is available
     /// to schedule on an executor but cannot be scheduled because no resources are available.
     fn set_pending_tasks_queue_size(&self, value: u64);
@@ -66,8 +72,9 @@ impl SchedulerMetricsCollector for NoopMetricsCollector {
     fn record_completed(&self, _job_id: &str, _queued_at: u64, _completed_att: u64) {}
     fn record_failed(&self, _job_id: &str, _queued_at: u64, _failed_at: u64) {}
     fn record_cancelled(&self, _job_id: &str) {}
+    fn record_process_event(&self, _event_type: &str, _processing_time_ms: u64) {}
+    fn record_event_failed(&self, _event_type: &str) {}
     fn set_pending_tasks_queue_size(&self, _value: u64) {}
-
     fn gather_metrics(&self) -> Result<Option<(Vec<u8>, String)>> {
         Ok(None)
     }

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -70,6 +70,26 @@ pub enum QueryStageSchedulerEvent {
     Tick,
 }
 
+impl QueryStageSchedulerEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            QueryStageSchedulerEvent::JobQueued { .. } => "JobQueued",
+            QueryStageSchedulerEvent::JobSubmitted { .. } => "JobSubmitted",
+            QueryStageSchedulerEvent::JobPlanningFailed { .. } => "JobPlanningFailed",
+            QueryStageSchedulerEvent::JobFinished { .. } => "JobFinished",
+            QueryStageSchedulerEvent::JobRunningFailed { .. } => "JobRunningFailed",
+            QueryStageSchedulerEvent::JobUpdated(_) => "JobUpdated",
+            QueryStageSchedulerEvent::JobCancel(_) => "JobCancel",
+            QueryStageSchedulerEvent::JobDataClean(_) => "JobDataClean",
+            QueryStageSchedulerEvent::TaskUpdating(_, _) => "TaskUpdating",
+            QueryStageSchedulerEvent::ReservationOffering(_) => "ReservationOffering",
+            QueryStageSchedulerEvent::ExecutorLost(_, _) => "ExecutorLost",
+            QueryStageSchedulerEvent::CancelTasks(_) => "CancelTasks",
+            QueryStageSchedulerEvent::Tick => "Tick",
+        }
+    }
+}
+
 impl Debug for QueryStageSchedulerEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -17,7 +17,7 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use tracing::{debug, error, info};
@@ -74,27 +74,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
     pub(crate) fn metrics_collector(&self) -> &dyn SchedulerMetricsCollector {
         self.metrics_collector.as_ref()
     }
-}
 
-#[async_trait]
-impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
-    EventAction<QueryStageSchedulerEvent> for QueryStageScheduler<T, U>
-{
-    fn on_start(&self) {
-        info!("Starting QueryStageScheduler");
-    }
-
-    fn on_stop(&self) {
-        info!("Stopping QueryStageScheduler")
-    }
-
-    async fn on_receive(
+    async fn process_event(
         &self,
         event: QueryStageSchedulerEvent,
-        tx_event: &mpsc::Sender<QueryStageSchedulerEvent>,
-        _rx_event: &mpsc::Receiver<QueryStageSchedulerEvent>,
+        tx_event: EventSender<QueryStageSchedulerEvent>,
     ) -> Result<()> {
-        let tx_event = EventSender::new(tx_event.clone());
         match event {
             QueryStageSchedulerEvent::JobQueued {
                 job_id,
@@ -353,6 +338,44 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         }
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
+    EventAction<QueryStageSchedulerEvent> for QueryStageScheduler<T, U>
+{
+    fn on_start(&self) {
+        info!("Starting QueryStageScheduler");
+    }
+
+    fn on_stop(&self) {
+        info!("Stopping QueryStageScheduler")
+    }
+
+    async fn on_receive(
+        &self,
+        event: QueryStageSchedulerEvent,
+        tx_event: &mpsc::Sender<QueryStageSchedulerEvent>,
+        _rx_event: &mpsc::Receiver<QueryStageSchedulerEvent>,
+    ) -> Result<()> {
+        let tx_event = EventSender::new(tx_event.clone());
+
+        let start = Instant::now();
+        let event_type = event.event_type();
+
+        match self.process_event(event, tx_event).await {
+            Ok(_) => {
+                self.metrics_collector
+                    .record_process_event(event_type, start.elapsed().as_millis() as u64);
+                Ok(())
+            }
+            Err(e) => {
+                self.metrics_collector
+                    .record_process_event(event_type, start.elapsed().as_millis() as u64);
+                Err(e)
+            }
+        }
     }
 
     fn on_error(&self, error: BallistaError) {

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -373,6 +373,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             Err(e) => {
                 self.metrics_collector
                     .record_process_event(event_type, start.elapsed().as_millis() as u64);
+                self.metrics_collector.record_event_failed(event_type);
                 Err(e)
             }
         }

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -752,6 +752,10 @@ impl SchedulerMetricsCollector for TestMetricsCollector {
         guard.push(MetricEvent::Cancelled(job_id.to_owned()));
     }
 
+    fn record_process_event(&self, _event_type: &str, _processing_time_ms: u64) {}
+
+    fn record_event_failed(&self, _event_type: &str) {}
+
     fn set_pending_tasks_queue_size(&self, _value: u64) {}
 
     fn gather_metrics(&self) -> Result<Option<(Vec<u8>, String)>> {


### PR DESCRIPTION
Add some additional metrics from scheduler:

1. Event processing time to measure how long it takes to process `QueryStageSchedulerEvents` 
2. Counter for event processing failures. 