### PR TITLE
Event loop optimization

### DIFF
--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -89,6 +89,8 @@ warp = "0.3"
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.11.0" }
+criterion = { version = "0.4", features = ["async_tokio"] }
+pprof = { version = "0.11", features = ["flamegraph","criterion","frame-pointer"]}
 
 [build-dependencies]
 configure_me_codegen = "=0.4.0"
@@ -96,3 +98,7 @@ tonic-build = { version = "0.8", default-features = false, features = [
     "transport",
     "prost",
 ] }
+
+[[bench]]
+harness = false
+name = "scheduler_events"

--- a/ballista/scheduler/benches/scheduler_events.rs
+++ b/ballista/scheduler/benches/scheduler_events.rs
@@ -1,0 +1,331 @@
+use async_trait::async_trait;
+use ballista_core::config::TaskSchedulingPolicy;
+use ballista_core::error::{BallistaError, Result};
+use ballista_core::serde::protobuf::job_status::Status;
+use ballista_core::serde::protobuf::{
+    task_status, JobStatus, ShuffleWritePartition, SuccessfulTask, TaskDefinition,
+    TaskStatus,
+};
+use ballista_core::serde::scheduler::{
+    ExecutorData, ExecutorMetadata, ExecutorSpecification,
+};
+use ballista_core::serde::BallistaCodec;
+use ballista_core::utils::default_session_builder;
+use ballista_scheduler::cluster::BallistaCluster;
+use ballista_scheduler::config::{SchedulerConfig, TaskDistribution};
+use ballista_scheduler::metrics::NoopMetricsCollector;
+use ballista_scheduler::scheduler_server::SchedulerServer;
+use ballista_scheduler::state::execution_graph::TaskDescription;
+use ballista_scheduler::state::executor_manager::ExecutorManager;
+use ballista_scheduler::state::task_manager::TaskLauncher;
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::common::Statistics;
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::execution::context::{SessionState, TaskContext};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::{
+    EmptyRecordBatchStream, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+};
+use datafusion::prelude::{col, count, SessionContext};
+use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
+use pprof::criterion::{Output, PProfProfiler};
+use std::any::Any;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Builder;
+use tokio::sync::mpsc;
+use tracing_subscriber::EnvFilter;
+
+fn dummy_table_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::Utf8, true),
+    ]))
+}
+
+#[derive(Debug, Clone)]
+struct DummyTable(usize);
+
+#[async_trait]
+impl TableProvider for DummyTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        dummy_table_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DummyTableExec(self.0)))
+    }
+}
+
+#[derive(Debug)]
+struct DummyTableExec(usize);
+
+#[async_trait]
+impl ExecutionPlan for DummyTableExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        dummy_table_schema()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(self.0)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::common::Result<SendableRecordBatchStream> {
+        Ok(Box::pin(EmptyRecordBatchStream::new(dummy_table_schema())))
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}
+
+struct Launcher(mpsc::Sender<(String, TaskStatus)>);
+
+#[async_trait]
+impl TaskLauncher<LogicalPlanNode, PhysicalPlanNode> for Launcher {
+    fn prepare_task_definition(
+        &self,
+        _ctx: Arc<SessionContext>,
+        _task: TaskDescription,
+    ) -> Result<TaskDefinition> {
+        unimplemented!("why are you being called!")
+    }
+
+    async fn launch_tasks(
+        &self,
+        executor: &ExecutorMetadata,
+        tasks: Vec<TaskDescription>,
+        _executor_manager: &ExecutorManager,
+    ) -> Result<()> {
+        // Simulate a delay required to call the executor RPC
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        for task in tasks {
+            let shuffle_write_partitions = (0..task
+                .output_partitioning
+                .as_ref()
+                .map(|p| p.partition_count())
+                .unwrap_or(1))
+                .map(|part| ShuffleWritePartition {
+                    partitions: task
+                        .partitions
+                        .partitions
+                        .iter()
+                        .map(|p| *p as u32)
+                        .collect(),
+                    output_partition: part as u32,
+                    path: "/path/to/partition".to_string(),
+                    num_batches: 8,
+                    num_rows: 8 * 1024,
+                    num_bytes: 8 * 1024 * 1024,
+                })
+                .collect();
+
+            self.0
+                .send((
+                    executor.id.clone(),
+                    TaskStatus {
+                        task_id: task.task_id as u32,
+                        job_id: task.partitions.job_id.clone(),
+                        stage_id: task.partitions.stage_id as u32,
+                        stage_attempt_num: task.stage_attempt_num as u32,
+                        partitions: task
+                            .partitions
+                            .partitions
+                            .iter()
+                            .map(|p| *p as u32)
+                            .collect(),
+                        launch_time: 0,
+                        start_exec_time: 0,
+                        end_exec_time: 0,
+                        metrics: vec![],
+                        status: Some(task_status::Status::Successful(SuccessfulTask {
+                            executor_id: executor.id.clone(),
+                            partitions: shuffle_write_partitions,
+                        })),
+                    },
+                ))
+                .await
+                .map_err(|e| {
+                    BallistaError::Internal(format!("Error sending status: {e:?}"))
+                })?;
+        }
+
+        Ok(())
+    }
+}
+
+async fn setup_env(
+    num_executors: usize,
+) -> Arc<SchedulerServer<LogicalPlanNode, PhysicalPlanNode>> {
+    let scheduler_name = "bench-server".to_string();
+
+    let cluster =
+        BallistaCluster::new_memory(scheduler_name.clone(), default_session_builder);
+
+    let config = SchedulerConfig::default()
+        .with_task_distribution(TaskDistribution::Bias)
+        .with_scheduler_policy(TaskSchedulingPolicy::PushStaged);
+
+    let metrics = Arc::new(NoopMetricsCollector::default());
+
+    let codec = BallistaCodec::default();
+
+    let (status_tx, mut status_rx) = mpsc::channel(10_000);
+
+    let launcher = Arc::new(Launcher(status_tx));
+
+    let mut server = SchedulerServer::new_with_task_launcher(
+        scheduler_name.clone(),
+        cluster,
+        codec,
+        config,
+        metrics,
+        launcher,
+    );
+
+    server.init().await.unwrap();
+
+    let server = Arc::new(server);
+
+    for id in 0..num_executors {
+        let executor_meta = ExecutorMetadata {
+            id: format!("executor-{id}"),
+            host: "127.0.0.1".to_string(),
+            port: 7799,
+            grpc_port: 7799,
+            specification: ExecutorSpecification { task_slots: 10 },
+        };
+
+        let executor_data = ExecutorData {
+            executor_id: format!("executor-{id}"),
+            total_task_slots: 10,
+            available_task_slots: 10,
+        };
+        server
+            .state
+            .executor_manager
+            .register_executor(executor_meta, executor_data, false, false)
+            .await
+            .unwrap();
+    }
+
+    let server_clone = server.clone();
+    tokio::spawn(async move {
+        while let Some((executor_id, status)) = status_rx.recv().await {
+            server_clone
+                .update_task_status(&executor_id, vec![status])
+                .await
+                .unwrap();
+        }
+    });
+
+    server
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let mut group = c.benchmark_group("benchmarks");
+
+    group
+        .sample_size(10)
+        .sampling_mode(SamplingMode::Flat)
+        .measurement_time(Duration::from_secs(30));
+
+    group.bench_function("scheduler_event", move |b| {
+        let rt = Builder::new_multi_thread().enable_all().build().unwrap();
+
+        b.to_async(rt).iter(|| async move {
+            let server = setup_env(100).await;
+
+            let ctx = Arc::new(SessionContext::default());
+
+            let plan = ctx
+                .read_table(Arc::new(DummyTable(1000)))
+                .unwrap()
+                .aggregate(vec![col("a")], vec![count(col("b"))])
+                .unwrap()
+                .logical_plan()
+                .clone();
+
+            let mut completions = vec![];
+
+            for id in 0..50 {
+                let job_id = format!("job-{id}");
+                server
+                    .submit_job(&job_id, "", ctx.clone(), &plan)
+                    .await
+                    .unwrap();
+
+                let server = server.clone();
+                completions.push(async move {
+                    loop {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+
+                        if let Ok(Some(JobStatus {
+                            status: Some(Status::Successful(_)),
+                            ..
+                        })) = server.state.task_manager.get_job_status(&job_id).await
+                        {
+                            break;
+                        }
+                    }
+                })
+            }
+
+            futures::future::join_all(completions).await
+        });
+    });
+
+    group.finish()
+}
+
+criterion_group! {
+    name = benches;
+    config  = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -364,7 +364,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         let reservations = self
             .state
             .executor_manager
-            .register_executor(metadata, executor_data, false)
+            .register_executor(metadata, executor_data, false, true)
             .await?;
 
         // If we are using push-based scheduling then reserve this executors slots and send
@@ -456,7 +456,7 @@ mod test {
             scheduler
                 .state
                 .executor_manager
-                .register_executor(executor_metadata, executor_data, false)
+                .register_executor(executor_metadata, executor_data, false, false)
                 .await?;
         }
 

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -241,9 +241,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
                             .await?;
                     }
 
-                    self.state
-                        .offer_reservation(reservations, tx_event)
-                        .await?;
+                    self.state.offer_reservation(reservations, tx_event).await?;
 
                     self.set_pending_tasks(
                         self.state.task_manager.get_pending_task_count(),

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -295,13 +295,16 @@ impl ExecutorManager {
         metadata: ExecutorMetadata,
         specification: ExecutorData,
         reserve: bool,
+        test_connection: bool,
     ) -> Result<Vec<ExecutorReservation>> {
         debug!(
             "registering executor {} with {} task slots",
             metadata.id, specification.total_task_slots
         );
 
-        self.test_scheduler_connectivity(&metadata).await?;
+        if test_connection {
+            self.test_scheduler_connectivity(&metadata).await?;
+        }
 
         if !reserve {
             self.cluster_state
@@ -500,7 +503,7 @@ mod test {
 
         for (executor_metadata, executor_data) in executors {
             executor_manager
-                .register_executor(executor_metadata, executor_data, false)
+                .register_executor(executor_metadata, executor_data, false, false)
                 .await?;
         }
 
@@ -548,7 +551,7 @@ mod test {
 
         for (executor_metadata, executor_data) in executors {
             executor_manager
-                .register_executor(executor_metadata, executor_data, false)
+                .register_executor(executor_metadata, executor_data, false, false)
                 .await?;
         }
 
@@ -602,7 +605,7 @@ mod test {
 
         for (executor_metadata, executor_data) in executors {
             executor_manager
-                .register_executor(executor_metadata, executor_data, false)
+                .register_executor(executor_metadata, executor_data, false, false)
                 .await?;
         }
 
@@ -651,7 +654,7 @@ mod test {
 
         for (executor_metadata, executor_data) in executors {
             let reservations = executor_manager
-                .register_executor(executor_metadata, executor_data, true)
+                .register_executor(executor_metadata, executor_data, true, false)
                 .await?;
 
             assert_eq!(reservations.len(), 4);
@@ -686,7 +689,7 @@ mod test {
 
         for (executor_metadata, executor_data) in executors {
             let _ = executor_manager
-                .register_executor(executor_metadata, executor_data, false)
+                .register_executor(executor_metadata, executor_data, false, false)
                 .await?;
         }
 

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -56,6 +56,7 @@ use tracing::{debug, error, info, warn};
 use tokio::sync::{watch, RwLock, RwLockWriteGuard};
 
 use crate::scheduler_server::timestamp_millis;
+use ballista_core::event_loop::EventSender;
 use ballista_core::physical_optimizer::OptimizeTaskGroup;
 use tracing::trace;
 
@@ -500,7 +501,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         &self,
         executor: &ExecutorMetadata,
         task_status: Vec<TaskStatus>,
-    ) -> Result<Vec<QueryStageSchedulerEvent>> {
+        tx_event: EventSender<QueryStageSchedulerEvent>,
+    ) -> Result<()> {
         let mut job_updates: HashMap<String, Vec<TaskStatus>> = HashMap::new();
         for status in task_status {
             trace!("Task Update\n{:?}", status);
@@ -509,7 +511,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             job_task_statuses.push(status);
         }
 
-        let mut events: Vec<QueryStageSchedulerEvent> = vec![];
         for (job_id, statuses) in job_updates {
             let num_tasks = statuses.len();
             debug!("Updating {} tasks in job {}", num_tasks, job_id);
@@ -530,11 +531,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             };
 
             for event in job_events {
-                events.push(event);
+                tx_event.post_event(event).await?;
             }
         }
 
-        Ok(events)
+        Ok(())
     }
 
     /// Take a list of executor reservations and fill them with tasks that are ready

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -470,7 +470,7 @@ impl SchedulerTest {
             scheduler
                 .state
                 .executor_manager
-                .register_executor(metadata, executor_data, false)
+                .register_executor(metadata, executor_data, false, false)
                 .await?;
         }
 


### PR DESCRIPTION
Digging into the bottlenecks we observed in the scheduler when we scaled up to 90 ec2 executors in cx180 and identified what I think is the root cause. When task updates come in too fast, launching new tasks inside the core event loop gums up the works. Added a micro-benchmark which demonstrates this. 

This PR moves task launching out of the event loop and some other small tweaks to minimize the possibility for any long-running tasks blocking the event loop. 