### PR TITLE
Add prometheus metrics for active task and task duration

### DIFF
--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -49,10 +49,12 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 futures = "0.3"
 hyper = "0.14.4"
+lazy_static = "1.4.0"
 log = "0.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 num_cpus = "1.13.0"
 parking_lot = "0.12"
+prometheus = { version = "0.13", features = ["process"] }
 tempfile = "3"
 tokio = { version = "1.0", features = [
     "macros",


### PR DESCRIPTION
Add two metrics:

1. Active task gauge so we can track current number of active tasks
2. Task duration so we can track task duration more correctly. We capture the shuffle write time now but it is unreliable because it relies on the execution plan metrics which are not preserved during lambda execution. This should be a more reliable metric