### PR TITLE
VTX-522: use execution error as a base error object

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,37 @@ on:
   pull_request:
 
 jobs:
+  react-build:
+    name: React build
+    runs-on: ubuntu-latest # proprietary github image, not ubuntu:latest
+    container:
+      image: ubuntu:latest # actual ubuntu:latest that ubuntu publishes
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install -y nodejs npm
+          npm install -g yarn
+          cat /etc/*-release
+          which node
+          which npm
+          which yarn
+          node --version
+          npm --version
+          yarn --version
+      - name: Run yarn build
+        run: |
+          cd ballista/scheduler/ui
+          pwd
+          yarn install
+          yarn build
+      - name: Save artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: react-artifacts
+          path: |
+            ballista/scheduler/ui/build
   # build the library, a compilation step used by multiple steps below
   linux-build-lib:
     name: Build Libraries on AMD64 Rust ${{ matrix.rust }}

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -355,7 +355,7 @@ message RunningTask {
 }
 
 message FailedTask {
-  string error = 1;
+  reserved 1;
   bool retryable = 2;
   // Whether this task failure should be counted to the maximum number of times the task is allowed to retry
   bool count_to_failures = 3;
@@ -376,20 +376,22 @@ message SuccessfulTask {
   // so we might want to think about some refactoring of the task definitions
   repeated ShuffleWritePartition partitions = 2;
 }
-
-message ExecutionError {}
-
 message FetchPartitionError {
   string executor_id = 1;
   uint32 map_stage_id = 2;
   repeated uint32 map_partitions = 3;
+  string message = 4;
 }
 
-message IOError {}
+message IOError {
+  string message = 1;
+}
 
 message ExecutorLost {}
 
-message ResultLost {}
+message ResultLost {
+  string message = 1;
+}
 
 message TaskKilled {}
 
@@ -544,11 +546,7 @@ message RunningJob {
   string scheduler = 3;
 }
 
-message FailedJob {
-  reserved 1;
-  uint64 queued_at = 2;
-  uint64 started_at = 3;
-  uint64 ended_at = 4;
+message ExecutionError {
   message NotImplemented {
     string message = 1;
   }
@@ -846,6 +844,13 @@ message FailedJob {
     Cancelled cancelled = 18;
   }
 }
+message FailedJob {
+  reserved 1;
+  uint64 queued_at = 2;
+  uint64 started_at = 3;
+  uint64 ended_at = 4;
+  ExecutionError error = 5;
+}
 
 message JobStatus {
   string job_id = 5;
@@ -948,7 +953,7 @@ service SchedulerGrpc {
 }
 
 service ExecutorGrpc {
-  rpc LaunchTask (LaunchTaskParams) returns (LaunchTaskResult) {}
+  rpc LaunchTask(LaunchTaskParams) returns (LaunchTaskResult) {}
 
   rpc StopExecutor(StopExecutorParams) returns (StopExecutorResult) {}
 

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -549,6 +549,9 @@ message RunningJob {
 }
 
 message ExecutionError {
+  message External {
+    string message = 1;
+  }
   message NotImplemented {
     string message = 1;
   }
@@ -844,6 +847,7 @@ message ExecutionError {
     GrpcActionError grpc_active_error = 16;
     FetchFailed fetch_failed = 17;
     Cancelled cancelled = 18;
+    External external = 19;
   }
 }
 message FailedJob {

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -549,9 +549,6 @@ message RunningJob {
 }
 
 message ExecutionError {
-  message External {
-    DatafusionError error = 1;
-  }
   message NotImplemented {
     string message = 1;
   }
@@ -847,7 +844,6 @@ message ExecutionError {
     GrpcActionError grpc_active_error = 16;
     FetchFailed fetch_failed = 17;
     Cancelled cancelled = 18;
-    External external = 19;
   }
 }
 message FailedJob {

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -550,7 +550,7 @@ message RunningJob {
 
 message ExecutionError {
   message External {
-    string message = 1;
+    DatafusionError error = 1;
   }
   message NotImplemented {
     string message = 1;

--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -542,21 +542,11 @@ impl From<&BallistaError> for execution_error::Error {
                 })
             }
             BallistaError::DataFusionError(error) => {
-                match error {
-                    // catch it here
-                    DataFusionError::External(_) => {
-                        execution_error::Error::External(execution_error::External {
-                            error: Some(execution_error::DatafusionError {
-                                error: Some(error.into()),
-                            }),
-                        })
-                    }
-                    other => execution_error::Error::DatafusionError(
-                        execution_error::DatafusionError {
-                            error: Some(other.into()),
-                        },
-                    ),
-                }
+                execution_error::Error::DatafusionError(
+                    execution_error::DatafusionError {
+                        error: Some(error.into()),
+                    },
+                )
             }
             BallistaError::SqlError(error) => {
                 execution_error::Error::SqlError(execution_error::SqlError {
@@ -953,9 +943,6 @@ impl Display for execution_error::Error {
                 write!(f, "FetchFailed: {}", error.message)
             }
             execution_error::Error::Cancelled(_) => write!(f, "Cancelled"),
-            execution_error::Error::External(error) => {
-                write!(f, "External: {:?}", error.error)
-            }
         }
     }
 }

--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -865,7 +865,8 @@ impl Display for execution_error::DatafusionError {
                     write!(f, "DatafusionError/ResourcesExhausted: {}", error.message)
                 }
                 execution_error::datafusion_error::Error::External(error) => {
-                    write!(f, "DatafusionError/External: {}", error.message)
+                    // to be better in UI, we will show only message
+                    write!(f, "{}", error.message)
                 }
                 execution_error::datafusion_error::Error::JitError(error) => {
                     write!(f, "DatafusionError/JitError: {}", error.message)

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -316,8 +316,8 @@ async fn fetch_partition(
     let host = metadata.host.as_str();
     let port = metadata.port as u16;
     let mut ballista_client = BallistaClient::try_new(host, port).await.map_err(|e| {
-        if let BallistaError::External(nested_error) = e {
-            nested_error
+        if let BallistaError::DataFusionError(err) = e {
+            err
         } else {
             DataFusionError::Execution(format!("{:?}", e))
         }

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -17,6 +17,7 @@
 
 use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
+use crate::error::BallistaError;
 use crate::serde::protobuf::execute_query_params::OptionalSessionId;
 use crate::serde::protobuf::{
     execute_query_params::Query, job_status, scheduler_grpc_client::SchedulerGrpcClient,
@@ -46,6 +47,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
+use tonic::transport::Channel;
 
 /// This operator sends a logical plan to a Ballista scheduler for execution and
 /// polls the scheduler until the query is complete and then fetches the resulting
@@ -235,7 +237,8 @@ async fn execute_query(
         .await
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
-    let mut scheduler = SchedulerGrpcClient::new(connection);
+    let mut scheduler: SchedulerGrpcClient<Channel> =
+        SchedulerGrpcClient::new(connection);
 
     let query_result = scheduler
         .execute_query(query)
@@ -312,9 +315,13 @@ async fn fetch_partition(
 
     let host = metadata.host.as_str();
     let port = metadata.port as u16;
-    let mut ballista_client = BallistaClient::try_new(host, port)
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    let mut ballista_client = BallistaClient::try_new(host, port).await.map_err(|e| {
+        if let BallistaError::External(nested_error) = e {
+            nested_error
+        } else {
+            DataFusionError::Execution(format!("{:?}", e))
+        }
+    })?;
 
     let map_partitions = location
         .map_partitions

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -315,13 +315,13 @@ async fn fetch_partition(
 
     let host = metadata.host.as_str();
     let port = metadata.port as u16;
-    let mut ballista_client = BallistaClient::try_new(host, port).await.map_err(|e| {
-        if let BallistaError::DataFusionError(err) = e {
-            err
-        } else {
-            DataFusionError::Execution(format!("{:?}", e))
-        }
-    })?;
+    let mut ballista_client =
+        BallistaClient::try_new(host, port)
+            .await
+            .map_err(|e| match e {
+                BallistaError::DataFusionError(err) => err,
+                _ => DataFusionError::Execution(format!("{:?}", e)),
+            })?;
 
     let map_partitions = location
         .map_partitions

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::error::BallistaError;
 use crate::utils;
 
 use crate::serde::protobuf::ShuffleWritePartition;
@@ -208,7 +209,10 @@ impl ShuffleWriterExec {
                         &write_metrics.write_time,
                     )
                     .await
-                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+                    .map_err(|e| match e {
+                        BallistaError::External(err) => err,
+                        other => DataFusionError::Execution(format!("{other:?}")),
+                    })?;
 
                     write_metrics
                         .input_rows

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -210,7 +210,7 @@ impl ShuffleWriterExec {
                     )
                     .await
                     .map_err(|e| match e {
-                        BallistaError::External(err) => err,
+                        BallistaError::DataFusionError(err) => err,
                         other => DataFusionError::Execution(format!("{other:?}")),
                     })?;
 

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -618,8 +618,6 @@ pub struct RunningTask {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FailedTask {
-    #[prost(string, tag = "1")]
-    pub error: ::prost::alloc::string::String,
     #[prost(bool, tag = "2")]
     pub retryable: bool,
     /// Whether this task failure should be counted to the maximum number of times the task is allowed to retry
@@ -660,9 +658,6 @@ pub struct SuccessfulTask {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExecutionError {}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchPartitionError {
     #[prost(string, tag = "1")]
     pub executor_id: ::prost::alloc::string::String,
@@ -670,16 +665,24 @@ pub struct FetchPartitionError {
     pub map_stage_id: u32,
     #[prost(uint32, repeated, tag = "3")]
     pub map_partitions: ::prost::alloc::vec::Vec<u32>,
+    #[prost(string, tag = "4")]
+    pub message: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IoError {}
+pub struct IoError {
+    #[prost(string, tag = "1")]
+    pub message: ::prost::alloc::string::String,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorLost {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ResultLost {}
+pub struct ResultLost {
+    #[prost(string, tag = "1")]
+    pub message: ::prost::alloc::string::String,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskKilled {}
@@ -949,21 +952,15 @@ pub struct RunningJob {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FailedJob {
-    #[prost(uint64, tag = "2")]
-    pub queued_at: u64,
-    #[prost(uint64, tag = "3")]
-    pub started_at: u64,
-    #[prost(uint64, tag = "4")]
-    pub ended_at: u64,
+pub struct ExecutionError {
     #[prost(
-        oneof = "failed_job::Error",
+        oneof = "execution_error::Error",
         tags = "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18"
     )]
-    pub error: ::core::option::Option<failed_job::Error>,
+    pub error: ::core::option::Option<execution_error::Error>,
 }
-/// Nested message and enum types in `FailedJob`.
-pub mod failed_job {
+/// Nested message and enum types in `ExecutionError`.
+pub mod execution_error {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NotImplemented {
@@ -1646,6 +1643,18 @@ pub mod failed_job {
         #[prost(message, tag = "18")]
         Cancelled(Cancelled),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FailedJob {
+    #[prost(uint64, tag = "2")]
+    pub queued_at: u64,
+    #[prost(uint64, tag = "3")]
+    pub started_at: u64,
+    #[prost(uint64, tag = "4")]
+    pub ended_at: u64,
+    #[prost(message, optional, tag = "5")]
+    pub error: ::core::option::Option<ExecutionError>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -968,8 +968,8 @@ pub mod execution_error {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct External {
-        #[prost(string, tag = "1")]
-        pub message: ::prost::alloc::string::String,
+        #[prost(message, optional, tag = "1")]
+        pub error: ::core::option::Option<DatafusionError>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1,6 +1,7 @@
 /// /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Ballista Physical Plan
 /// /////////////////////////////////////////////////////////////////////////////////////////////////
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BallistaPhysicalPlanNode {
     #[prost(
@@ -13,6 +14,7 @@ pub struct BallistaPhysicalPlanNode {
 }
 /// Nested message and enum types in `BallistaPhysicalPlanNode`.
 pub mod ballista_physical_plan_node {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PhysicalPlanType {
         #[prost(message, tag = "1")]
@@ -25,6 +27,7 @@ pub mod ballista_physical_plan_node {
         CoalesceTasks(super::CoalesceTaskExecNode),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CoalesceTaskExecNode {
     #[prost(message, optional, tag = "1")]
@@ -32,6 +35,7 @@ pub struct CoalesceTaskExecNode {
     #[prost(uint32, repeated, tag = "2")]
     pub partitions: ::prost::alloc::vec::Vec<u32>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleWriterExecNode {
     /// TODO it seems redundant to provide job and stage id here since we also have them
@@ -49,6 +53,7 @@ pub struct ShuffleWriterExecNode {
         ::datafusion_proto::protobuf::PhysicalHashRepartition,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnresolvedShuffleExecNode {
     #[prost(uint32, tag = "1")]
@@ -60,6 +65,7 @@ pub struct UnresolvedShuffleExecNode {
     #[prost(uint32, tag = "4")]
     pub output_partition_count: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleReaderExecNode {
     #[prost(message, repeated, tag = "1")]
@@ -67,6 +73,7 @@ pub struct ShuffleReaderExecNode {
     #[prost(message, optional, tag = "2")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleReaderPartition {
     /// each partition of a shuffle read can read data from multiple locations
@@ -76,6 +83,7 @@ pub struct ShuffleReaderPartition {
 /// /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Ballista Scheduling
 /// /////////////////////////////////////////////////////////////////////////////////////////////////
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutionGraph {
     #[prost(string, tag = "1")]
@@ -107,6 +115,7 @@ pub struct ExecutionGraph {
     #[prost(bool, tag = "14")]
     pub circuit_breaker_tripped: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StageAttempts {
     #[prost(uint32, tag = "1")]
@@ -114,6 +123,7 @@ pub struct StageAttempts {
     #[prost(uint32, repeated, tag = "2")]
     pub stage_attempt_num: ::prost::alloc::vec::Vec<u32>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutionGraphStage {
     #[prost(oneof = "execution_graph_stage::StageType", tags = "1, 2, 3, 4")]
@@ -121,6 +131,7 @@ pub struct ExecutionGraphStage {
 }
 /// Nested message and enum types in `ExecutionGraphStage`.
 pub mod execution_graph_stage {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum StageType {
         #[prost(message, tag = "1")]
@@ -133,6 +144,7 @@ pub mod execution_graph_stage {
         FailedStage(super::FailedStage),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnResolvedStage {
     #[prost(uint32, tag = "1")]
@@ -154,6 +166,7 @@ pub struct UnResolvedStage {
         ::prost::alloc::string::String,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResolvedStage {
     #[prost(uint32, tag = "1")]
@@ -177,6 +190,7 @@ pub struct ResolvedStage {
         ::prost::alloc::string::String,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessfulStage {
     #[prost(uint32, tag = "1")]
@@ -200,6 +214,7 @@ pub struct SuccessfulStage {
     #[prost(uint32, tag = "9")]
     pub stage_attempt_num: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FailedStage {
     #[prost(uint32, tag = "1")]
@@ -223,6 +238,7 @@ pub struct FailedStage {
     #[prost(uint32, tag = "9")]
     pub stage_attempt_num: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskInfo {
     #[prost(uint32, tag = "1")]
@@ -249,6 +265,7 @@ pub struct TaskInfo {
 }
 /// Nested message and enum types in `TaskInfo`.
 pub mod task_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         #[prost(message, tag = "8")]
@@ -259,6 +276,7 @@ pub mod task_info {
         Successful(super::SuccessfulTask),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GraphStageInput {
     #[prost(uint32, tag = "1")]
@@ -268,6 +286,7 @@ pub struct GraphStageInput {
     #[prost(bool, tag = "3")]
     pub complete: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskInputPartitions {
     #[prost(uint32, tag = "1")]
@@ -275,6 +294,7 @@ pub struct TaskInputPartitions {
     #[prost(message, repeated, tag = "2")]
     pub partition_location: ::prost::alloc::vec::Vec<PartitionLocation>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValuePair {
     #[prost(string, tag = "1")]
@@ -282,6 +302,7 @@ pub struct KeyValuePair {
     #[prost(string, tag = "2")]
     pub value: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Action {
     /// configuration settings
@@ -292,6 +313,7 @@ pub struct Action {
 }
 /// Nested message and enum types in `Action`.
 pub mod action {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum ActionType {
         /// Fetch a partition from an executor
@@ -299,6 +321,7 @@ pub mod action {
         FetchPartition(super::FetchPartition),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutePartition {
     #[prost(string, tag = "1")]
@@ -318,6 +341,7 @@ pub struct ExecutePartition {
         ::datafusion_proto::protobuf::PhysicalHashRepartition,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchPartition {
     #[prost(string, tag = "1")]
@@ -333,6 +357,7 @@ pub struct FetchPartition {
     #[prost(uint32, tag = "6")]
     pub port: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionLocation {
     #[prost(string, tag = "6")]
@@ -352,6 +377,7 @@ pub struct PartitionLocation {
     #[prost(string, tag = "5")]
     pub path: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionStats {
     #[prost(int64, tag = "1")]
@@ -363,6 +389,7 @@ pub struct PartitionStats {
     #[prost(message, repeated, tag = "4")]
     pub column_stats: ::prost::alloc::vec::Vec<ColumnStats>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ColumnStats {
     #[prost(message, optional, tag = "1")]
@@ -374,11 +401,13 @@ pub struct ColumnStats {
     #[prost(uint32, tag = "4")]
     pub distinct_count: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OperatorMetricsSet {
     #[prost(message, repeated, tag = "1")]
     pub metrics: ::prost::alloc::vec::Vec<OperatorMetric>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedCount {
     #[prost(string, tag = "1")]
@@ -386,6 +415,7 @@ pub struct NamedCount {
     #[prost(uint64, tag = "2")]
     pub value: u64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedGauge {
     #[prost(string, tag = "1")]
@@ -393,6 +423,7 @@ pub struct NamedGauge {
     #[prost(uint64, tag = "2")]
     pub value: u64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedTime {
     #[prost(string, tag = "1")]
@@ -400,6 +431,7 @@ pub struct NamedTime {
     #[prost(uint64, tag = "2")]
     pub value: u64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OperatorMetric {
     #[prost(oneof = "operator_metric::Metric", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
@@ -407,6 +439,7 @@ pub struct OperatorMetric {
 }
 /// Nested message and enum types in `OperatorMetric`.
 pub mod operator_metric {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Metric {
         #[prost(uint64, tag = "1")]
@@ -432,6 +465,7 @@ pub mod operator_metric {
     }
 }
 /// Used by scheduler
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorMetadata {
     #[prost(string, tag = "1")]
@@ -446,6 +480,7 @@ pub struct ExecutorMetadata {
     pub specification: ::core::option::Option<ExecutorSpecification>,
 }
 /// Used by grpc
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorRegistration {
     #[prost(string, tag = "1")]
@@ -465,12 +500,14 @@ pub struct ExecutorRegistration {
 pub mod executor_registration {
     /// "optional" keyword is stable in protoc 3.15 but prost is still on 3.14 (see <https://github.com/tokio-rs/prost/issues/430> and <https://github.com/tokio-rs/prost/pull/455>)
     /// this syntax is ugly but is binary compatible with the "optional" keyword (see <https://stackoverflow.com/questions/42622015/how-to-define-an-optional-field-in-protobuf-3>)
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum OptionalHost {
         #[prost(string, tag = "2")]
         Host(::prost::alloc::string::String),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorHeartbeat {
     #[prost(string, tag = "1")]
@@ -483,6 +520,7 @@ pub struct ExecutorHeartbeat {
     #[prost(message, optional, tag = "4")]
     pub status: ::core::option::Option<ExecutorStatus>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorMetric {
     /// TODO add more metrics
@@ -492,12 +530,14 @@ pub struct ExecutorMetric {
 /// Nested message and enum types in `ExecutorMetric`.
 pub mod executor_metric {
     /// TODO add more metrics
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Metric {
         #[prost(uint64, tag = "1")]
         AvailableMemory(u64),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorStatus {
     #[prost(oneof = "executor_status::Status", tags = "1, 2, 3, 4")]
@@ -505,6 +545,7 @@ pub struct ExecutorStatus {
 }
 /// Nested message and enum types in `ExecutorStatus`.
 pub mod executor_status {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         #[prost(string, tag = "1")]
@@ -517,11 +558,13 @@ pub mod executor_status {
         Terminating(::prost::alloc::string::String),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorSpecification {
     #[prost(message, repeated, tag = "1")]
     pub resources: ::prost::alloc::vec::Vec<ExecutorResource>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorResource {
     /// TODO add more resources
@@ -531,12 +574,14 @@ pub struct ExecutorResource {
 /// Nested message and enum types in `ExecutorResource`.
 pub mod executor_resource {
     /// TODO add more resources
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Resource {
         #[prost(uint32, tag = "1")]
         TaskSlots(u32),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AvailableTaskSlots {
     #[prost(string, tag = "1")]
@@ -544,11 +589,13 @@ pub struct AvailableTaskSlots {
     #[prost(uint32, tag = "2")]
     pub slots: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorTaskSlots {
     #[prost(message, repeated, tag = "1")]
     pub task_slots: ::prost::alloc::vec::Vec<AvailableTaskSlots>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorData {
     #[prost(string, tag = "1")]
@@ -556,6 +603,7 @@ pub struct ExecutorData {
     #[prost(message, repeated, tag = "2")]
     pub resources: ::prost::alloc::vec::Vec<ExecutorResourcePair>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorResourcePair {
     #[prost(message, optional, tag = "1")]
@@ -563,11 +611,13 @@ pub struct ExecutorResourcePair {
     #[prost(message, optional, tag = "2")]
     pub available: ::core::option::Option<ExecutorResource>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunningTask {
     #[prost(string, tag = "1")]
     pub executor_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FailedTask {
     #[prost(bool, tag = "2")]
@@ -580,6 +630,7 @@ pub struct FailedTask {
 }
 /// Nested message and enum types in `FailedTask`.
 pub mod failed_task {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum FailedReason {
         #[prost(message, tag = "4")]
@@ -597,6 +648,7 @@ pub mod failed_task {
         TaskKilled(super::TaskKilled),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessfulTask {
     #[prost(string, tag = "1")]
@@ -618,6 +670,7 @@ pub struct FetchPartitionError {
     #[prost(string, tag = "4")]
     pub message: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IoError {
     #[prost(string, tag = "1")]
@@ -626,6 +679,7 @@ pub struct IoError {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorLost {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResultLost {
     #[prost(string, tag = "1")]
@@ -634,6 +688,7 @@ pub struct ResultLost {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskKilled {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleWritePartition {
     #[prost(uint32, repeated, tag = "1")]
@@ -649,6 +704,7 @@ pub struct ShuffleWritePartition {
     #[prost(uint64, tag = "5")]
     pub num_bytes: u64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskStatus {
     #[prost(uint32, tag = "1")]
@@ -674,6 +730,7 @@ pub struct TaskStatus {
 }
 /// Nested message and enum types in `TaskStatus`.
 pub mod task_status {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         #[prost(message, tag = "9")]
@@ -684,6 +741,7 @@ pub mod task_status {
         Successful(super::SuccessfulTask),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollWorkParams {
     #[prost(message, optional, tag = "1")]
@@ -694,6 +752,7 @@ pub struct PollWorkParams {
     #[prost(message, repeated, tag = "3")]
     pub task_status: ::prost::alloc::vec::Vec<TaskStatus>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskDefinition {
     #[prost(uint32, tag = "1")]
@@ -720,6 +779,7 @@ pub struct TaskDefinition {
     #[prost(message, repeated, tag = "11")]
     pub props: ::prost::alloc::vec::Vec<KeyValuePair>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SessionSettings {
     #[prost(message, repeated, tag = "1")]
@@ -727,6 +787,7 @@ pub struct SessionSettings {
     #[prost(message, repeated, tag = "2")]
     pub extensions: ::prost::alloc::vec::Vec<KeyValuePair>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JobSessionConfig {
     #[prost(string, tag = "1")]
@@ -734,21 +795,25 @@ pub struct JobSessionConfig {
     #[prost(message, repeated, tag = "2")]
     pub configs: ::prost::alloc::vec::Vec<KeyValuePair>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollWorkResult {
     #[prost(message, repeated, tag = "1")]
     pub tasks: ::prost::alloc::vec::Vec<TaskDefinition>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterExecutorParams {
     #[prost(message, optional, tag = "1")]
     pub metadata: ::core::option::Option<ExecutorRegistration>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterExecutorResult {
     #[prost(bool, tag = "1")]
     pub success: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeartBeatParams {
     #[prost(string, tag = "1")]
@@ -760,12 +825,14 @@ pub struct HeartBeatParams {
     #[prost(message, optional, tag = "4")]
     pub metadata: ::core::option::Option<ExecutorRegistration>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeartBeatResult {
     /// TODO it's from Spark for BlockManager
     #[prost(bool, tag = "1")]
     pub reregister: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StopExecutorParams {
     #[prost(string, tag = "1")]
@@ -777,8 +844,10 @@ pub struct StopExecutorParams {
     #[prost(bool, tag = "3")]
     pub force: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StopExecutorResult {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorStoppedParams {
     #[prost(string, tag = "1")]
@@ -787,8 +856,10 @@ pub struct ExecutorStoppedParams {
     #[prost(string, tag = "2")]
     pub reason: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorStoppedResult {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateTaskStatusParams {
     #[prost(string, tag = "1")]
@@ -797,11 +868,13 @@ pub struct UpdateTaskStatusParams {
     #[prost(message, repeated, tag = "2")]
     pub task_status: ::prost::alloc::vec::Vec<TaskStatus>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateTaskStatusResult {
     #[prost(bool, tag = "1")]
     pub success: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteQueryParams {
     #[prost(message, repeated, tag = "4")]
@@ -815,6 +888,7 @@ pub struct ExecuteQueryParams {
 }
 /// Nested message and enum types in `ExecuteQueryParams`.
 pub mod execute_query_params {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Query {
         #[prost(bytes, tag = "1")]
@@ -822,17 +896,20 @@ pub mod execute_query_params {
         #[prost(string, tag = "2")]
         Sql(::prost::alloc::string::String),
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum OptionalSessionId {
         #[prost(string, tag = "3")]
         SessionId(::prost::alloc::string::String),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteSqlParams {
     #[prost(string, tag = "1")]
     pub sql: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteQueryResult {
     #[prost(string, tag = "1")]
@@ -840,11 +917,13 @@ pub struct ExecuteQueryResult {
     #[prost(string, tag = "2")]
     pub session_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetJobStatusParams {
     #[prost(string, tag = "1")]
     pub job_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessfulJob {
     #[prost(message, repeated, tag = "1")]
@@ -858,12 +937,14 @@ pub struct SuccessfulJob {
     #[prost(bool, tag = "5")]
     pub circuit_breaker_tripped: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueuedJob {
     #[prost(uint64, tag = "1")]
     pub queued_at: u64,
 }
 /// TODO: add progress report
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunningJob {
     #[prost(uint64, tag = "1")]
@@ -873,11 +954,12 @@ pub struct RunningJob {
     #[prost(string, tag = "3")]
     pub scheduler: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutionError {
     #[prost(
         oneof = "execution_error::Error",
-        tags = "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18"
+        tags = "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
     )]
     pub error: ::core::option::Option<execution_error::Error>,
 }
@@ -885,20 +967,29 @@ pub struct ExecutionError {
 pub mod execution_error {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct External {
+        #[prost(string, tag = "1")]
+        pub message: ::prost::alloc::string::String,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NotImplemented {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct General {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Internal {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArrowError {
         #[prost(
@@ -909,77 +1000,94 @@ pub mod execution_error {
     }
     /// Nested message and enum types in `ArrowError`.
     pub mod arrow_error {
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct NotYetImplemented {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ExternalError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct CastError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct MemoryError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ParseError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct SchemaError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ComputeError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct DivideByZero {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct CsvError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct JsonError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct IoError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct InvalidArgumentError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ParquetError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct CDataInterface {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct DictionaryKeyOverflowError {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct RunEndIndexOverflowError {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Error {
             #[prost(message, tag = "1")]
@@ -1018,6 +1126,7 @@ pub mod execution_error {
             SqlError(super::SqlError),
         }
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ParserError {
         #[prost(oneof = "parser_error::Error", tags = "1, 2, 3")]
@@ -1025,18 +1134,22 @@ pub mod execution_error {
     }
     /// Nested message and enum types in `ParserError`.
     pub mod parser_error {
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct TokenizerError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ParserError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct RecursionLimitExceeded {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Error {
             #[prost(message, tag = "1")]
@@ -1047,6 +1160,7 @@ pub mod execution_error {
             RecursionLimitExceeded(RecursionLimitExceeded),
         }
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DatafusionError {
         #[prost(
@@ -1057,6 +1171,7 @@ pub mod execution_error {
     }
     /// Nested message and enum types in `DatafusionError`.
     pub mod datafusion_error {
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ParquetError {
             #[prost(oneof = "parquet_error::Error", tags = "1, 2, 3, 4, 5, 6")]
@@ -1064,26 +1179,31 @@ pub mod execution_error {
         }
         /// Nested message and enum types in `ParquetError`.
         pub mod parquet_error {
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct General {
                 #[prost(string, tag = "1")]
                 pub message: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct NotYetImplemented {
                 #[prost(string, tag = "1")]
                 pub message: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct Eof {
                 #[prost(string, tag = "1")]
                 pub message: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct ArrowError {
                 #[prost(string, tag = "1")]
                 pub message: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct IndexOutOfBound {
                 #[prost(uint32, tag = "1")]
@@ -1091,11 +1211,13 @@ pub mod execution_error {
                 #[prost(uint32, tag = "2")]
                 pub bound: u32,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct External {
                 #[prost(string, tag = "1")]
                 pub message: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Oneof)]
             pub enum Error {
                 #[prost(message, tag = "1")]
@@ -1112,6 +1234,7 @@ pub mod execution_error {
                 External(External),
             }
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct SchemaError {
             #[prost(oneof = "schema_error::Error", tags = "1, 2, 3, 4")]
@@ -1119,6 +1242,7 @@ pub mod execution_error {
         }
         /// Nested message and enum types in `SchemaError`.
         pub mod schema_error {
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct AmbiguousReference {
                 #[prost(string, optional, tag = "1")]
@@ -1126,6 +1250,7 @@ pub mod execution_error {
                 #[prost(string, tag = "2")]
                 pub name: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct DuplicateQualifiedField {
                 #[prost(string, tag = "1")]
@@ -1133,11 +1258,13 @@ pub mod execution_error {
                 #[prost(string, tag = "2")]
                 pub name: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct DuplicateUnqualifiedField {
                 #[prost(string, tag = "1")]
                 pub name: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct FieldNotFound {
                 #[prost(string, tag = "1")]
@@ -1147,6 +1274,7 @@ pub mod execution_error {
                     ::prost::alloc::string::String,
                 >,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Oneof)]
             pub enum Error {
                 #[prost(message, tag = "1")]
@@ -1159,11 +1287,13 @@ pub mod execution_error {
                 FieldNotFound(FieldNotFound),
             }
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct AvroError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ObjectStore {
             #[prost(oneof = "object_store::Error", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
@@ -1171,6 +1301,7 @@ pub mod execution_error {
         }
         /// Nested message and enum types in `ObjectStore`.
         pub mod object_store {
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct Generic {
                 #[prost(string, tag = "1")]
@@ -1178,6 +1309,7 @@ pub mod execution_error {
                 #[prost(string, tag = "2")]
                 pub source: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct NotFound {
                 #[prost(string, tag = "1")]
@@ -1185,21 +1317,25 @@ pub mod execution_error {
                 #[prost(string, tag = "2")]
                 pub source: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct InvalidPath {
                 #[prost(string, tag = "1")]
                 pub source: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct JoinError {
                 #[prost(string, tag = "1")]
                 pub source: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct NotSupported {
                 #[prost(string, tag = "1")]
                 pub source: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct AlreadyExists {
                 #[prost(string, tag = "1")]
@@ -1207,8 +1343,10 @@ pub mod execution_error {
                 #[prost(string, tag = "2")]
                 pub source: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct NotImplemented {}
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct UnknownConfigurationKey {
                 #[prost(string, tag = "1")]
@@ -1216,6 +1354,7 @@ pub mod execution_error {
                 #[prost(string, tag = "2")]
                 pub key: ::prost::alloc::string::String,
             }
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Oneof)]
             pub enum Error {
                 #[prost(message, tag = "1")]
@@ -1236,46 +1375,55 @@ pub mod execution_error {
                 UnknownConfigurationKey(UnknownConfigurationKey),
             }
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct IoError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct NotImplemented {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Internal {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Plan {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Execution {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ResourcesExhausted {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct External {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct JitError {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Context {
             #[prost(string, tag = "1")]
@@ -1285,11 +1433,13 @@ pub mod execution_error {
                 ::prost::alloc::boxed::Box<super::DatafusionError>,
             >,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Substrait {
             #[prost(string, tag = "1")]
             pub message: ::prost::alloc::string::String,
         }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Error {
             #[prost(message, tag = "1")]
@@ -1328,21 +1478,25 @@ pub mod execution_error {
             ParserError(super::ParserError),
         }
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SqlError {
         #[prost(message, optional, tag = "1")]
         pub error: ::core::option::Option<ParserError>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IoError {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TonicError {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GrpcError {
         #[prost(string, tag = "1")]
@@ -1440,16 +1594,19 @@ pub mod execution_error {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TokioError {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GrpcActionError {
         #[prost(string, tag = "1")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FetchFailed {
         #[prost(string, tag = "1")]
@@ -1461,8 +1618,10 @@ pub mod execution_error {
         #[prost(string, tag = "4")]
         pub message: ::prost::alloc::string::String,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Cancelled {}
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Error {
         #[prost(message, tag = "5")]
@@ -1493,6 +1652,8 @@ pub mod execution_error {
         FetchFailed(FetchFailed),
         #[prost(message, tag = "18")]
         Cancelled(Cancelled),
+        #[prost(message, tag = "19")]
+        External(External),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1519,6 +1680,7 @@ pub struct JobStatus {
 }
 /// Nested message and enum types in `JobStatus`.
 pub mod job_status {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         #[prost(message, tag = "1")]
@@ -1531,11 +1693,13 @@ pub mod job_status {
         Successful(super::SuccessfulJob),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetJobStatusResult {
     #[prost(message, optional, tag = "1")]
     pub status: ::core::option::Option<JobStatus>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetFileMetadataParams {
     #[prost(string, tag = "1")]
@@ -1543,33 +1707,40 @@ pub struct GetFileMetadataParams {
     #[prost(string, tag = "2")]
     pub file_type: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetFileMetadataResult {
     #[prost(message, optional, tag = "1")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FilePartitionMetadata {
     #[prost(string, repeated, tag = "1")]
     pub filename: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelJobParams {
     #[prost(string, tag = "1")]
     pub job_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelJobResult {
     #[prost(bool, tag = "1")]
     pub cancelled: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CleanJobDataParams {
     #[prost(string, tag = "1")]
     pub job_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CleanJobDataResult {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LaunchTaskParams {
     /// Allow to launch a task set to an executor at once
@@ -1578,29 +1749,35 @@ pub struct LaunchTaskParams {
     #[prost(string, tag = "2")]
     pub scheduler_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LaunchTaskResult {
     /// TODO when part of the task set are scheduled successfully
     #[prost(bool, tag = "1")]
     pub success: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelTasksParams {
     #[prost(message, repeated, tag = "1")]
     pub task_infos: ::prost::alloc::vec::Vec<RunningTaskInfo>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelTasksResult {
     #[prost(bool, tag = "1")]
     pub cancelled: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveJobDataParams {
     #[prost(string, tag = "1")]
     pub job_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveJobDataResult {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunningTaskInfo {
     #[prost(uint32, tag = "1")]
@@ -1610,6 +1787,7 @@ pub struct RunningTaskInfo {
     #[prost(uint32, tag = "3")]
     pub stage_id: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerKey {
     #[prost(string, tag = "1")]
@@ -1625,11 +1803,13 @@ pub struct CircuitBreakerKey {
     #[prost(string, tag = "6")]
     pub task_id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerUpdateRequest {
     #[prost(message, repeated, tag = "1")]
     pub updates: ::prost::alloc::vec::Vec<CircuitBreakerUpdate>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerUpdate {
     #[prost(message, optional, tag = "1")]
@@ -1637,11 +1817,13 @@ pub struct CircuitBreakerUpdate {
     #[prost(double, tag = "2")]
     pub percent: f64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerUpdateResponse {
     #[prost(message, repeated, tag = "1")]
     pub commands: ::prost::alloc::vec::Vec<CircuitBreakerCommand>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerCommand {
     #[prost(message, optional, tag = "1")]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -959,18 +959,15 @@ pub struct RunningJob {
 pub struct ExecutionError {
     #[prost(
         oneof = "execution_error::Error",
-        tags = "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
+        tags = "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18"
     )]
     pub error: ::core::option::Option<execution_error::Error>,
 }
 /// Nested message and enum types in `ExecutionError`.
 pub mod execution_error {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct External {
-        #[prost(message, optional, tag = "1")]
-        pub error: ::core::option::Option<DatafusionError>,
-    }
+    /// message External {
+    ///    DatafusionError error = 1;
+    /// }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NotImplemented {
@@ -1650,10 +1647,9 @@ pub mod execution_error {
         GrpcActiveError(GrpcActionError),
         #[prost(message, tag = "17")]
         FetchFailed(FetchFailed),
+        /// External external = 19;
         #[prost(message, tag = "18")]
         Cancelled(Cancelled),
-        #[prost(message, tag = "19")]
-        External(External),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -72,6 +72,7 @@ prometheus = { version = "0.13", features = ["process"], optional = true }
 prost = "0.11"
 prost-types = { version = "0.11.0" }
 rand = "0.8"
+regex = "1.8.1"
 serde = { version = "1", features = ["derive"] }
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
@@ -87,7 +88,6 @@ tracing-subscriber = { version = "0.3.15", features = [
 ] }
 uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
-regex = "1.8.1"
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.11.0" }

--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -30,8 +30,8 @@ use ballista_core::config::BallistaConfig;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::protobuf::job_status::Status;
 use ballista_core::serde::protobuf::{
-    self, AvailableTaskSlots, ExecutorHeartbeat, ExecutorTaskSlots, FailedJob,
-    KeyValuePair, QueuedJob,
+    self, AvailableTaskSlots, ExecutionError, ExecutorHeartbeat, ExecutorTaskSlots,
+    FailedJob, KeyValuePair, QueuedJob,
 };
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use ballista_core::serde::BallistaCodec;
@@ -620,7 +620,9 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 job_id: job_id.clone(),
                 job_name,
                 status: Some(Status::Failed(FailedJob {
-                    error: Some(reason.as_ref().into()),
+                    error: Some(ExecutionError {
+                        error: Some(reason.as_ref().into()),
+                    }),
                     queued_at,
                     started_at: 0,
                     ended_at: 0,

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -25,8 +25,8 @@ use async_trait::async_trait;
 use ballista_core::config::BallistaConfig;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::protobuf::{
-    executor_status, AvailableTaskSlots, ExecutorHeartbeat, ExecutorStatus,
-    ExecutorTaskSlots, FailedJob, QueuedJob,
+    executor_status, AvailableTaskSlots, ExecutionError, ExecutorHeartbeat,
+    ExecutorStatus, ExecutorTaskSlots, FailedJob, QueuedJob,
 };
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use dashmap::DashMap;
@@ -460,7 +460,9 @@ impl JobState for InMemoryJobState {
                         job_id,
                         job_name,
                         status: Some(Status::Failed(FailedJob {
-                            error: Some(reason.as_ref().into()),
+                            error: Some(ExecutionError {
+                                error: Some(reason.as_ref().into()),
+                            }),
                             queued_at,
                             started_at: 0,
                             ended_at: timestamp_millis(),

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -21,7 +21,10 @@ use std::fmt::{Debug, Formatter};
 use datafusion::logical_expr::LogicalPlan;
 
 use crate::state::execution_graph::RunningTaskInfo;
-use ballista_core::{error::BallistaError, serde::protobuf::TaskStatus};
+use ballista_core::{
+    error::BallistaError,
+    serde::protobuf::{execution_error, TaskStatus},
+};
 use datafusion::prelude::SessionContext;
 use std::sync::Arc;
 
@@ -58,7 +61,7 @@ pub enum QueryStageSchedulerEvent {
         job_id: String,
         queued_at: u64,
         failed_at: u64,
-        error: Arc<BallistaError>,
+        error: Arc<execution_error::Error>,
     },
     JobUpdated(String),
     JobCancel(String),

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -618,11 +618,10 @@ mod test {
                     end_exec_time: timestamp,
                     metrics: vec![],
                     status: Some(task_status::Status::Failed(FailedTask {
-                        error: "ERROR".to_string(),
                         retryable: false,
                         count_to_failures: false,
                         failed_reason: Some(failed_task::FailedReason::ExecutionError(
-                            ExecutionError {},
+                            ExecutionError { error: None },
                         )),
                     })),
                 }

--- a/ballista/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_graph/execution_stage.rs
@@ -951,7 +951,6 @@ impl SuccessfulStage {
     /// Returns the number of running tasks that were reset
     pub fn reset_tasks(&mut self, executor: &str) -> usize {
         let mut reset = 0;
-        let failure_reason = format!("Task failure due to Executor {executor} lost");
         for task in self.task_infos.iter_mut() {
             match task {
                 TaskInfo {
@@ -971,10 +970,13 @@ impl SuccessfulStage {
                         end_exec_time: 0,
                         finish_time: 0,
                         task_status: task_status::Status::Failed(FailedTask {
-                            error: failure_reason.clone(),
                             retryable: true,
                             count_to_failures: false,
-                            failed_reason: Some(FailedReason::ResultLost(ResultLost {})),
+                            failed_reason: Some(FailedReason::ResultLost(ResultLost {
+                                message: format!(
+                                    "Task failure due to Executor {executor} lost"
+                                ),
+                            })),
                         }),
                     };
                     reset += 1;

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -29,7 +29,8 @@ use futures::future::try_join_all;
 
 use crate::cluster::JobState;
 use ballista_core::serde::protobuf::{
-    self, execution_error, JobStatus, KeyValuePair, TaskDefinition, TaskStatus,
+    self, execution_error, job_status, JobStatus, KeyValuePair, SuccessfulJob,
+    TaskDefinition, TaskStatus,
 };
 use ballista_core::serde::scheduler::to_proto::hash_partitioning_to_proto;
 use ballista_core::serde::scheduler::ExecutorMetadata;

--- a/ballista/tests/Cargo.toml
+++ b/ballista/tests/Cargo.toml
@@ -10,28 +10,28 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1"
+async-trait = "0.1.41"
+ballista = { path = "../client", version = "0.11.0" }
+ballista-core = { path = "../core", version = "0.11.0" }
 ballista-executor = { path = "../executor", version = "0.11.0" }
 ballista-scheduler = { path = "../scheduler", version = "0.11.0" }
-ballista-core = { path = "../core", version = "0.11.0" }
-ballista = { path = "../client", version = "0.11.0" }
-
-tokio = { version = "1.0", features = ["full"] }
-lazy_static = "1.4"
-anyhow = "1"
-datafusion.workspace = true
-async-trait = "0.1.41"
+datafusion = { workspace = true } 
+datafusion-proto= { workspace = true }
+env_logger = "0.10"
 futures = "0.3"
-datafusion-proto.workspace = true
-tonic = "0.8"
+lazy_static = "1.4"
 prost = "0.11"
 prost-types = "0.11"
-env_logger = "0.10"
+
+tokio = { version = "1.0", features = ["full"] }
+tonic = "0.8"
 
 [build-dependencies]
+anyhow = "1"
+prost-build = { version = "0.11" }
 rustc_version = "0.4.0"
 tonic-build = { version = "0.8", default-features = false, features = [
     "transport",
     "prost",
 ] }
-prost-build = { version = "0.11" }
-anyhow = "1"

--- a/ballista/tests/src/proto.rs
+++ b/ballista/tests/src/proto.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TestTable {
     #[prost(uint64, tag = "1")]
@@ -5,6 +6,7 @@ pub struct TestTable {
     #[prost(uint64, tag = "2")]
     pub global_limit: u64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TestTableExec {
     #[prost(message, optional, tag = "1")]

--- a/ballista/tests/src/test_logical_codec.rs
+++ b/ballista/tests/src/test_logical_codec.rs
@@ -75,8 +75,9 @@ impl LogicalExtensionCodec for TestLogicalCodec {
 
             return Ok(());
         }
-        return Err(DataFusionError::Internal(
+
+        Err(DataFusionError::Internal(
             "Failed to encode table provider, only TestTable allowed".to_owned(),
-        ));
+        ))
     }
 }


### PR DESCRIPTION
In this PR I'm trying to use the newly introduced `execution_error` as a general error across the codebase

we had a few rudimental wrapping which caused some issues, they were removed