### PR TITLE
Add handling for scheduler termination

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -954,6 +954,14 @@ message CircuitBreakerCommand {
   CircuitBreakerKey key = 1;
 }
 
+message SchedulerLostParams {
+  string scheduler_id = 1;
+  string executor_id = 2;
+  repeated TaskStatus task_status = 3;
+}
+
+message SchedulerLostResponse {}
+
 service SchedulerGrpc {
   // Executors must poll the scheduler for heartbeat and to receive tasks
   rpc PollWork(PollWorkParams) returns (PollWorkResult) {}
@@ -980,6 +988,9 @@ service SchedulerGrpc {
   rpc CleanJobData(CleanJobDataParams) returns (CleanJobDataResult) {}
 
   rpc SendCircuitBreakerUpdate(CircuitBreakerUpdateRequest) returns (CircuitBreakerUpdateResponse) {}
+
+  // Used when an executor fails to update task status with a curator scheduler for tasks
+  rpc SchedulerLost(SchedulerLostParams) returns (SchedulerLostResponse) {}
 }
 
 service ExecutorGrpc {

--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -37,7 +37,7 @@ use datafusion::error::DataFusionError;
 use itertools::Itertools;
 use sqlparser::parser::{self, ParserError};
 
-pub type Result<T> = result::Result<T, BallistaError>;
+pub type Result<T, E = BallistaError> = result::Result<T, E>;
 
 /// Ballista error
 #[derive(Debug)]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1821,6 +1821,19 @@ pub struct CircuitBreakerCommand {
     #[prost(message, optional, tag = "1")]
     pub key: ::core::option::Option<CircuitBreakerKey>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SchedulerLostParams {
+    #[prost(string, tag = "1")]
+    pub scheduler_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub executor_id: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub task_status: ::prost::alloc::vec::Vec<TaskStatus>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SchedulerLostResponse {}
 /// Generated client implementations.
 pub mod scheduler_grpc_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -2212,6 +2225,34 @@ pub mod scheduler_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// Used when an executor fails to update task status with a curator scheduler for tasks
+        pub async fn scheduler_lost(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SchedulerLostParams>,
+        ) -> std::result::Result<
+            tonic::Response<super::SchedulerLostResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ballista.protobuf.SchedulerGrpc/SchedulerLost",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("ballista.protobuf.SchedulerGrpc", "SchedulerLost"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated client implementations.
@@ -2484,6 +2525,14 @@ pub mod scheduler_grpc_server {
             request: tonic::Request<super::CircuitBreakerUpdateRequest>,
         ) -> std::result::Result<
             tonic::Response<super::CircuitBreakerUpdateResponse>,
+            tonic::Status,
+        >;
+        /// Used when an executor fails to update task status with a curator scheduler for tasks
+        async fn scheduler_lost(
+            &self,
+            request: tonic::Request<super::SchedulerLostParams>,
+        ) -> std::result::Result<
+            tonic::Response<super::SchedulerLostResponse>,
             tonic::Status,
         >;
     }
@@ -3053,6 +3102,52 @@ pub mod scheduler_grpc_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = SendCircuitBreakerUpdateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/ballista.protobuf.SchedulerGrpc/SchedulerLost" => {
+                    #[allow(non_camel_case_types)]
+                    struct SchedulerLostSvc<T: SchedulerGrpc>(pub Arc<T>);
+                    impl<
+                        T: SchedulerGrpc,
+                    > tonic::server::UnaryService<super::SchedulerLostParams>
+                    for SchedulerLostSvc<T> {
+                        type Response = super::SchedulerLostResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SchedulerLostParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).scheduler_lost(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SchedulerLostSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -63,6 +63,7 @@ tokio = { version = "1.0", features = [
     "parking_lot",
     "signal",
 ] }
+tokio-retry = "0.3.0"
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { workspace = true }
 tracing = "0.1.36"

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -26,9 +26,9 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 
-use log::{debug, error, info, warn};
 use tonic::transport::Channel;
-use tonic::{Request, Response, Status};
+use tonic::{Code, Request, Response, Status};
+use tracing::{debug, error, info, warn};
 
 use ballista_core::error::BallistaError;
 use ballista_core::serde::protobuf::{
@@ -37,8 +37,8 @@ use ballista_core::serde::protobuf::{
     scheduler_grpc_client::SchedulerGrpcClient,
     CancelTasksParams, CancelTasksResult, ExecutorMetric, ExecutorStatus,
     HeartBeatParams, LaunchTaskParams, LaunchTaskResult, RegisterExecutorParams,
-    RemoveJobDataParams, RemoveJobDataResult, StopExecutorParams, StopExecutorResult,
-    TaskStatus, UpdateTaskStatusParams,
+    RemoveJobDataParams, RemoveJobDataResult, SchedulerLostParams, StopExecutorParams,
+    StopExecutorResult, TaskStatus, UpdateTaskStatusParams,
 };
 
 use ballista_core::serde::scheduler::TaskDefinition;
@@ -51,6 +51,7 @@ use datafusion_proto::{
     logical_plan::AsLogicalPlan,
     physical_plan::{from_proto::parse_protobuf_hash_partitioning, AsExecutionPlan},
 };
+use lazy_static::lazy_static;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::task::JoinHandle;
 
@@ -63,6 +64,7 @@ use crate::executor::Executor;
 use crate::scheduler_client_registry::SchedulerClientRegistry;
 use crate::shutdown::ShutdownNotifier;
 use crate::{as_task_status, TaskExecutionTimes};
+use tokio_retry::strategy::FixedInterval;
 
 pub type ServerHandle = JoinHandle<Result<(), BallistaError>>;
 type SchedulerClients = Arc<DashMap<String, SchedulerGrpcClient<Channel>>>;
@@ -553,9 +555,94 @@ fn task_identity(task: &TaskDefinition) -> String {
     )
 }
 
+lazy_static! {
+    static ref STATUS_RETRY_POLICY: Vec<Duration> =
+        FixedInterval::from_millis(10).take(3).collect();
+}
+
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskRunnerPool<T, U> {
     fn new(executor_server: Arc<ExecutorServer<T, U>>) -> Self {
         Self { executor_server }
+    }
+
+    async fn send_status_update(
+        scheduler: &mut SchedulerGrpcClient<Channel>,
+        executor_id: &str,
+        status: Vec<TaskStatus>,
+    ) -> Result<(), Status> {
+        let mut retries = STATUS_RETRY_POLICY.iter();
+
+        loop {
+            if let Err(e) = scheduler
+                .update_task_status(UpdateTaskStatusParams {
+                    executor_id: executor_id.to_owned(),
+                    task_status: status.clone(),
+                })
+                .await
+            {
+                warn!("failed to update task status: {e:?}");
+                if let Some(interval) = retries.next() {
+                    if matches!(
+                        e.code(),
+                        Code::Unknown
+                            | Code::Unavailable
+                            | Code::Internal
+                            | Code::Aborted
+                    ) {
+                        // we can retry, sleep for specified interval and retry
+                        tokio::time::sleep(*interval).await;
+                    } else {
+                        // error is not retryable, return error
+                        return Err(e);
+                    }
+                } else {
+                    // retries are exhausted, return error
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    async fn send_scheduler_lost(
+        scheduler: &mut SchedulerGrpcClient<Channel>,
+        executor_id: &str,
+        scheduler_id: &str,
+        status: Vec<TaskStatus>,
+    ) -> Result<(), Status> {
+        let mut retries = STATUS_RETRY_POLICY.iter();
+
+        loop {
+            if let Err(e) = scheduler
+                .scheduler_lost(SchedulerLostParams {
+                    executor_id: executor_id.to_owned(),
+                    scheduler_id: scheduler_id.to_owned(),
+                    task_status: status.clone(),
+                })
+                .await
+            {
+                warn!(
+                    "failed to send scheduler lost for scheduler {scheduler_id}: {e:?}"
+                );
+                if let Some(interval) = retries.next() {
+                    if matches!(
+                        e.code(),
+                        Code::Unknown
+                            | Code::Unavailable
+                            | Code::Internal
+                            | Code::Aborted
+                    ) {
+                        // we can retry, sleep for specified interval and retry
+                        tokio::time::sleep(*interval).await;
+                    } else {
+                        // error is not retryable, return error
+                        return Err(e);
+                    }
+                } else {
+                    // retries are exhausted, return error
+                    return Err(e);
+                }
+            }
+        }
     }
 
     fn start(
@@ -622,28 +709,62 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskRunnerPool<T,
                 for (scheduler_id, tasks_status) in curator_task_status_map.into_iter() {
                     match executor_server.get_scheduler_client(&scheduler_id).await {
                         Ok(mut scheduler) => {
-                            if let Err(e) = scheduler
-                                .update_task_status(UpdateTaskStatusParams {
-                                    executor_id: executor_server
-                                        .executor
-                                        .metadata
-                                        .id
-                                        .clone(),
-                                    task_status: tasks_status.clone(),
-                                })
-                                .await
+                            let executor_id = &executor_server.executor.metadata.id;
+                            if let Err(e) = TaskRunnerPool::<T, U>::send_status_update(
+                                &mut scheduler,
+                                executor_id,
+                                tasks_status.clone(),
+                            )
+                            .await
                             {
+                                let task_ids = tasks_status.iter().map(|status| {
+                                    format!(
+                                        "{}/{}/{:?}",
+                                        status.job_id, status.stage_id, status.partitions
+                                    )
+                                });
                                 error!(
-                                    "Fail to update tasks {:?} due to {:?}",
-                                    tasks_status, e
+                                    executor_id,
+                                    error = %e,
+                                    ?task_ids,
+                                    "failed to update task status",
                                 );
+
+                                let mut scheduler =
+                                    executor_server.scheduler_to_register.clone();
+
+                                if let Err(e) = Self::send_scheduler_lost(
+                                    &mut scheduler,
+                                    &executor_server.executor.metadata.id,
+                                    &scheduler_id,
+                                    tasks_status,
+                                )
+                                .await
+                                {
+                                    error!(scheduler_id, error = %e, "failed to send scheduler lost");
+                                }
                             }
                         }
                         Err(e) => {
                             error!(
-                                "Fail to connect to scheduler {} due to {:?}",
-                                scheduler_id, e
+                                scheduler_id,
+                                error = %e,
+                                "failed to get scheduler client",
                             );
+
+                            let mut scheduler =
+                                executor_server.scheduler_to_register.clone();
+
+                            if let Err(e) = Self::send_scheduler_lost(
+                                &mut scheduler,
+                                &executor_server.executor.metadata.id,
+                                &scheduler_id,
+                                tasks_status,
+                            )
+                            .await
+                            {
+                                error!(scheduler_id, error = %e, "failed to send scheduler lost");
+                            }
                         }
                     }
                 }

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -67,6 +67,7 @@ pub enum QueryStageSchedulerEvent {
     JobCancel(String),
     JobDataClean(String),
     TaskUpdating(String, Vec<TaskStatus>),
+    SchedulerLost(String, String, Vec<TaskStatus>),
     ReservationOffering(Vec<ExecutorReservation>),
     ExecutorLost(String, Option<String>),
     CancelTasks(Vec<RunningTaskInfo>),
@@ -85,6 +86,7 @@ impl QueryStageSchedulerEvent {
             QueryStageSchedulerEvent::JobCancel(_) => "JobCancel",
             QueryStageSchedulerEvent::JobDataClean(_) => "JobDataClean",
             QueryStageSchedulerEvent::TaskUpdating(_, _) => "TaskUpdating",
+            QueryStageSchedulerEvent::SchedulerLost(_, _, _) => "SchedulerLost",
             QueryStageSchedulerEvent::ReservationOffering(_) => "ReservationOffering",
             QueryStageSchedulerEvent::ExecutorLost(_, _) => "ExecutorLost",
             QueryStageSchedulerEvent::CancelTasks(_) => "CancelTasks",
@@ -109,6 +111,9 @@ impl Debug for QueryStageSchedulerEvent {
             QueryStageSchedulerEvent::JobCancel(_) => write!(f, "JobCancel"),
             QueryStageSchedulerEvent::JobDataClean(_) => write!(f, "JobDataClean"),
             QueryStageSchedulerEvent::TaskUpdating(_, _) => write!(f, "TaskUpdating"),
+            QueryStageSchedulerEvent::SchedulerLost(_, _, _) => {
+                write!(f, "SchedulerLost")
+            }
             QueryStageSchedulerEvent::ReservationOffering(_) => {
                 write!(f, "ReservationOffering")
             }

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -30,6 +30,7 @@ use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
+use crate::state::executor_manager::ExecutorReservation;
 
 use crate::state::SchedulerState;
 
@@ -226,6 +227,27 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
                         num_status, executor_id, e
                     );
                     // TODO error handling
+                }
+            }
+            QueryStageSchedulerEvent::SchedulerLost(
+                scheduler_id,
+                executor_id,
+                task_status,
+            ) => {
+                if self.state.config.is_push_staged_scheduling() {
+                    let num_slots = task_status
+                        .into_iter()
+                        .map(|status| status.partitions.len())
+                        .sum::<usize>();
+
+                    let reservations = (0..num_slots)
+                        .map(|_| ExecutorReservation::new_free(executor_id.clone()))
+                        .collect();
+                    info!("Returning {num_slots} task slots for executor {executor_id} from lost scheduler {scheduler_id}");
+
+                    tx_event.post_event(QueryStageSchedulerEvent::ReservationOffering(
+                        reservations,
+                    ));
                 }
             }
             QueryStageSchedulerEvent::ReservationOffering(mut reservations) => {


### PR DESCRIPTION
Try to address issue we've seen in cx180. If a scheduler shuts down while it still has tasks outstanding on executors, then there will be no way for those executors to report status and hence no way for the task slots to be freed. 

To address that:
1. Add a new `scheduler_lost` rpc to the scheduler. This will simply return the task slots to the pool. In the future we can maybe use this to actually move the job to a new scheduler. 
2. If an executor cannot report status, then it should send a `scheduler_lost` rpc to the kerbernetes service endpoint. Any live schedulers should then be able to return the slots to the pool. 
3. Add some more robustness by adding retry to task status update so transient failures are less likely to cause queries to hang.  