### PR TITLE
Always handle errors in task runner and improve logging

### DIFF
--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -173,6 +173,11 @@ impl Executor {
         task_ctx: Arc<TaskContext>,
         _shuffle_output_partitioning: Option<Partitioning>,
     ) -> Result<Vec<protobuf::ShuffleWritePartition>, BallistaError> {
+        info!(
+            executor_id = self.metadata.id,
+            job_id, stage_id, task_id, "executing query stage"
+        );
+
         let _metric_guard = ActiveTaskMetricGuard::new(partitions.len());
 
         let (task, abort_handle) = futures::future::abortable(
@@ -204,7 +209,10 @@ impl Executor {
         job_id: String,
         stage_id: usize,
     ) -> Result<bool, BallistaError> {
-        info!(task_id, job_id, stage_id, "cancelling task");
+        info!(
+            executor_id = self.metadata.id,
+            task_id, job_id, stage_id, "cancelling task"
+        );
         if let Some((_, handle)) = self.remove_handle(job_id, task_id) {
             handle.abort();
             Ok(true)

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -39,6 +39,7 @@ use prometheus::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::watch;
+use tracing::info;
 
 lazy_static! {
     static ref ACTIVE_TASKS: IntGauge =
@@ -201,8 +202,9 @@ impl Executor {
         &self,
         task_id: usize,
         job_id: String,
-        _stage_id: usize,
+        stage_id: usize,
     ) -> Result<bool, BallistaError> {
+        info!(task_id, job_id, stage_id, "cancelling task");
         if let Some((_, handle)) = self.remove_handle(job_id, task_id) {
             handle.abort();
             Ok(true)

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -366,7 +366,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
             })
             .await
         {
-            error!(executor_id, error = %error, "error sending heartbeat with fenced status");
+            error!(executor_id, %error, "error sending heartbeat with fenced status");
         }
 
         // TODO we probably don't need a separate rpc call for this....

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -28,13 +28,13 @@ use arrow_flight::flight_service_server::FlightServiceServer;
 use datafusion::config::Extensions;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use log::{error, info, warn};
 use tempfile::TempDir;
 use tokio::fs::DirEntry;
 use tokio::signal;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::{fs, time};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
@@ -304,6 +304,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
         }
     };
     service_handlers.push(tokio::spawn(flight_server_run(
+        executor_id.clone(),
         addr,
         shutdown_noti.subscribe_for_shutdown(),
     )));
@@ -365,7 +366,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
             })
             .await
         {
-            error!("error sending heartbeat with fenced status: {:?}", error);
+            error!(executor_id, error = %error, "error sending heartbeat with fenced status");
         }
 
         // TODO we probably don't need a separate rpc call for this....
@@ -407,15 +408,19 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
 
 // Arrow flight service
 async fn flight_server_run(
+    executor_id: String,
     addr: SocketAddr,
     mut grpc_shutdown: Shutdown,
 ) -> Result<(), BallistaError> {
-    let service = BallistaFlightService::new();
-    let server = FlightServiceServer::new(service);
     info!(
-        "Ballista v{} Rust Executor Flight Server listening on {:?}",
-        BALLISTA_VERSION, addr
+        executor_id,
+        version = BALLISTA_VERSION,
+        address = %addr,
+        "starting flight server",
     );
+
+    let service = BallistaFlightService::new(&executor_id);
+    let server = FlightServiceServer::new(service);
 
     let shutdown_signal = grpc_shutdown.recv();
     let server_future = create_grpc_server()
@@ -423,7 +428,7 @@ async fn flight_server_run(
         .serve_with_shutdown(addr, shutdown_signal);
 
     server_future.await.map_err(|e| {
-        error!("Tonic error, Could not start Executor Flight Server.");
+        error!(executor_id, error = %e, "failed to start flight server");
         BallistaError::TonicError(e)
     })
 }
@@ -444,7 +449,7 @@ async fn check_services(
                 Err(e) => return Err(BallistaError::TokioError(e)),
             },
             None => {
-                info!("service handlers are all done with their work!");
+                info!("all service handles complete");
                 return Ok(());
             }
         }
@@ -464,27 +469,28 @@ async fn clean_shuffle_data_loop(work_dir: &str, seconds: u64) -> Result<()> {
                 match satisfy_dir_ttl(child, seconds).await {
                     Err(e) => {
                         error!(
-                            "Fail to check ttl for the directory {:?} due to {:?}",
-                            child_path, e
+                            directory = %child_path.to_string_lossy(),
+                            error = %e,
+                            "failed to check TTL for shuffle data directory",
                         )
                     }
                     Ok(false) => to_deleted.push(child_path),
                     Ok(_) => {}
                 }
             } else {
-                warn!("{:?} under the working directory is a not a directory and will be ignored when doing cleanup", child_path)
+                warn!(directory = %child_path.to_string_lossy(), "not a directory and will be ignored when doing cleanup")
             }
         } else {
-            error!("Fail to get metadata for file {:?}", child.path())
+            error!(path = %child.path().display(), "failed to get metadata for file")
         }
     }
     info!(
-        "The directories {:?} that have not been modified for {:?} seconds so that they will be deleted",
+        "directories {:?} that have not been modified for {:?} seconds so that they will be deleted",
         to_deleted, seconds
     );
     for del in to_deleted {
         if let Err(e) = fs::remove_dir_all(&del).await {
-            error!("Fail to remove the directory {:?} due to {}", del, e);
+            error!(directory = %del.to_string_lossy(), error = %e, "failed to remove directory");
         }
     }
     Ok(())
@@ -501,14 +507,14 @@ async fn clean_all_shuffle_data(work_dir: &str) -> Result<()> {
                 to_deleted.push(child.path().into_os_string())
             }
         } else {
-            error!("Can not get metadata from file: {:?}", child)
+            error!(path = %child.path().display(), "failed to get metadata for file")
         }
     }
 
-    info!("The work_dir {:?} will be deleted", &to_deleted);
+    info!("deleting work directories {to_deleted:?}");
     for del in to_deleted {
         if let Err(e) = fs::remove_dir_all(&del).await {
-            error!("Fail to remove the directory {:?} due to {}", del, e);
+            error!(directory = %del.to_string_lossy(), error = %e, "failed to remove directory");
         }
     }
     Ok(())

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -412,10 +412,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
                     TaskExecutionTimes {
                         launch_time,
                         start_exec_time,
-                        end_exec_time: SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_millis() as u64,
+                        end_exec_time: start_exec_time,
                     },
                 );
 

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -78,6 +78,7 @@ pub async fn new_standalone_executor<
         RuntimeConfig::new().with_temp_file_path(work_dir.clone()),
     );
 
+    let executor_id = executor_meta.id.clone();
     let executor = Arc::new(Executor::new(
         executor_meta,
         &work_dir,
@@ -87,7 +88,7 @@ pub async fn new_standalone_executor<
         None,
     ));
 
-    let service = BallistaFlightService::new();
+    let service = BallistaFlightService::new(executor_id);
     let server = FlightServiceServer::new(service);
     tokio::spawn(
         create_grpc_server()


### PR DESCRIPTION
[VTX-1189]

If the executor is not able to report some sort of task status for a task it has been assigned then there is no way for the task slots to be freed. This PR ensures that in all error scenarios we still send a task status back to the scheduler. 

I also went through and cleaned up a lot of the logging:
1. Use attributes wherever we can to create useful searchable fields 
2. Log the executor ID wherever we have it in scope so we can drill down on a particular executor in the logs when all we have is the ID (from the scheduler logs for example). 

[VTX-1189]: https://coralogix.atlassian.net/browse/VTX-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ