### PR TITLE
Handle task launch failures

### DIFF
--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -1061,7 +1061,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
         &self,
         request: Request<LaunchTaskParams>,
     ) -> Result<Response<LaunchTaskResult>, Status> {
-        // Reject new tasks is already in TERMINATING state
+        // Reject new tasks if in TERMINATING state
         if TERMINATING.load(Ordering::Acquire) {
             return Err(Status::unavailable("executor is terminating"));
         }

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -1061,6 +1061,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
         &self,
         request: Request<LaunchTaskParams>,
     ) -> Result<Response<LaunchTaskResult>, Status> {
+        // Reject new tasks is already in TERMINATING state
+        if TERMINATING.load(Ordering::Acquire) {
+            return Err(Status::unavailable("executor is terminating"));
+        }
+
         let LaunchTaskParams {
             tasks,
             scheduler_id,

--- a/ballista/scheduler/benches/scheduler_events.rs
+++ b/ballista/scheduler/benches/scheduler_events.rs
@@ -127,7 +127,7 @@ impl TaskLauncher<LogicalPlanNode, PhysicalPlanNode> for Launcher {
     fn prepare_task_definition(
         &self,
         _ctx: Arc<SessionContext>,
-        _task: TaskDescription,
+        _task: &TaskDescription,
     ) -> Result<TaskDefinition> {
         unimplemented!("why are you being called!")
     }
@@ -135,7 +135,7 @@ impl TaskLauncher<LogicalPlanNode, PhysicalPlanNode> for Launcher {
     async fn launch_tasks(
         &self,
         executor: &ExecutorMetadata,
-        tasks: Vec<TaskDescription>,
+        tasks: &[TaskDescription],
         _executor_manager: &ExecutorManager,
     ) -> Result<()> {
         // Simulate a delay required to call the executor RPC


### PR DESCRIPTION
[VTX-768]

Currently when the scheduler fails to launch a task (gRPC call to executor fails, etc) then those tasks will be forever stuck in running state and the job will hang indefinitely. 

With this update if we fail to launch then a synthetic task status will get generated so the tasks can be rescheduled. 

With that in place we can solve another issue where we have a sort of race condition. When the executor goes into terminating state and has no pending tasks it will go immediately into it's 30s shutdown wait. But between the time the executor goes into terminating status and the scheduler actually receives that status, the executor can have new tasks assigned. Since we can now handle task launch failures, as soon as the executor goes into `TERMINATING` status, it will start rejecting new tasks. 

[VTX-768]: https://coralogix.atlassian.net/browse/VTX-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ