### PR TITLE
Fix for terminating executors

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -499,6 +499,8 @@ message UpdateTaskStatusParams {
   string executor_id = 1;
   // All tasks must be reported until they reach the failed or completed state
   repeated TaskStatus task_status = 2;
+  // flag to indicate whether executor reporting status is terminating
+  bool executor_terminating = 3;
 }
 
 message UpdateTaskStatusResult {

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -867,6 +867,9 @@ pub struct UpdateTaskStatusParams {
     /// All tasks must be reported until they reach the failed or completed state
     #[prost(message, repeated, tag = "2")]
     pub task_status: ::prost::alloc::vec::Vec<TaskStatus>,
+    /// flag to indicate whether executor reporting status is terminating
+    #[prost(bool, tag = "3")]
+    pub executor_terminating: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -748,6 +748,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskRunnerPool<T,
                 .update_task_status(UpdateTaskStatusParams {
                     executor_id: executor_id.to_owned(),
                     task_status: status.clone(),
+                    executor_terminating: TERMINATING.load(Ordering::Acquire),
                 })
                 .await
             {

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -917,18 +917,20 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskRunnerPool<T,
                                     "failed to update task status",
                                 );
 
-                                let mut scheduler =
-                                    executor_server.scheduler_to_register.clone();
+                                if !TERMINATING.load(Ordering::Acquire) {
+                                    let mut scheduler =
+                                        executor_server.scheduler_to_register.clone();
 
-                                if let Err(e) = Self::send_scheduler_lost(
-                                    &mut scheduler,
-                                    &executor_server.executor.metadata.id,
-                                    &scheduler_id,
-                                    tasks_status,
-                                )
-                                .await
-                                {
-                                    error!(executor_id, scheduler_id, error = %e, "failed to send scheduler lost");
+                                    if let Err(e) = Self::send_scheduler_lost(
+                                        &mut scheduler,
+                                        &executor_server.executor.metadata.id,
+                                        &scheduler_id,
+                                        tasks_status,
+                                    )
+                                    .await
+                                    {
+                                        error!(executor_id, scheduler_id, error = %e, "failed to send scheduler lost");
+                                    }
                                 }
                             }
                         }

--- a/ballista/scheduler/benches/scheduler_events.rs
+++ b/ballista/scheduler/benches/scheduler_events.rs
@@ -351,7 +351,7 @@ async fn setup_env(
     tokio::spawn(async move {
         while let Some((executor_id, status)) = status_rx.recv().await {
             server_clone
-                .update_task_status(&executor_id, vec![status])
+                .update_task_status(&executor_id, vec![status], true)
                 .await
                 .unwrap();
         }

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -66,7 +66,7 @@ pub enum QueryStageSchedulerEvent {
     JobUpdated(String),
     JobCancel(String),
     JobDataClean(String),
-    TaskUpdating(String, Vec<TaskStatus>),
+    TaskUpdating(String, Vec<TaskStatus>, bool),
     SchedulerLost(String, String, Vec<TaskStatus>),
     ReservationOffering(Vec<ExecutorReservation>),
     ExecutorLost(String, Option<String>),
@@ -85,7 +85,7 @@ impl QueryStageSchedulerEvent {
             QueryStageSchedulerEvent::JobUpdated(_) => "JobUpdated",
             QueryStageSchedulerEvent::JobCancel(_) => "JobCancel",
             QueryStageSchedulerEvent::JobDataClean(_) => "JobDataClean",
-            QueryStageSchedulerEvent::TaskUpdating(_, _) => "TaskUpdating",
+            QueryStageSchedulerEvent::TaskUpdating(_, _, _) => "TaskUpdating",
             QueryStageSchedulerEvent::SchedulerLost(_, _, _) => "SchedulerLost",
             QueryStageSchedulerEvent::ReservationOffering(_) => "ReservationOffering",
             QueryStageSchedulerEvent::ExecutorLost(_, _) => "ExecutorLost",
@@ -110,7 +110,7 @@ impl Debug for QueryStageSchedulerEvent {
             QueryStageSchedulerEvent::JobUpdated(_) => write!(f, "JobUpdated"),
             QueryStageSchedulerEvent::JobCancel(_) => write!(f, "JobCancel"),
             QueryStageSchedulerEvent::JobDataClean(_) => write!(f, "JobDataClean"),
-            QueryStageSchedulerEvent::TaskUpdating(_, _) => write!(f, "TaskUpdating"),
+            QueryStageSchedulerEvent::TaskUpdating(_, _, _) => write!(f, "TaskUpdating"),
             QueryStageSchedulerEvent::SchedulerLost(_, _, _) => {
                 write!(f, "SchedulerLost")
             }


### PR DESCRIPTION
Previous commit changed the executor behavior so it starts rejecting tasks once it goes into terminating state. That causes a downstream issue since when the scheduler fails to launch a task it will re-offer those reservations to it's event loop. At that point there is nothing to check whether the executor is still alive so it will get new tasks assigned, those tasks will again fail to launch and it will go into a more-or-less infinite loop. 

With this change we just return the executor slots to the global pool instead of re-offering them to the event loop. In that case they will be returned and since the executor is already in terminating state, the slots will never be reassigned and eventually removed. In the case where the task launching was some spurious failure this adds some extra overhead but that should be rare enough to not be an issue. 