### PR TITLE
VTX-1274: show arrow external error back to user

### DIFF
--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -186,11 +186,18 @@ impl From<&DataFusionError> for datafusion_error::Error {
                 },
             ),
             DataFusionError::ArrowError(error) => {
-                    datafusion_error::Error::ArrowError(
-                            execution_error::ArrowError {
-                                error: Some(error.into()),
-                            },
-                        )
+                match error {
+                    ArrowError::ExternalError(err) => datafusion_error::Error::External(
+                        datafusion_error::External {
+                            message: err.to_string()
+                        },
+                    ),
+                    other_error => datafusion_error::Error::ArrowError(
+                        execution_error::ArrowError {
+                            error: Some(other_error.into()),
+                        },
+                    )
+                }
             },
             DataFusionError::ParquetError(err) => match err {
                 datafusion::parquet::errors::ParquetError::General(message) => {

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -965,9 +965,6 @@ pub struct ExecutionError {
 }
 /// Nested message and enum types in `ExecutionError`.
 pub mod execution_error {
-    /// message External {
-    ///    DatafusionError error = 1;
-    /// }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NotImplemented {
@@ -1647,7 +1644,6 @@ pub mod execution_error {
         GrpcActiveError(GrpcActionError),
         #[prost(message, tag = "17")]
         FetchFailed(FetchFailed),
-        /// External external = 19;
         #[prost(message, tag = "18")]
         Cancelled(Cancelled),
     }


### PR DESCRIPTION
Mark arrow external error as an error that can be returned back to the user