### PR TITLE
Update arrow and datafusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ exclude = ["python"]
 members = ["ballista-cli", "ballista/client", "ballista/core", "ballista/executor", "ballista/scheduler", "ballista/tests", "benchmarks", "examples"]
 
 [workspace.dependencies]
-arrow = { version = "38.0.0" }
-arrow-flight = { version = "38.0.0", features = ["flight-sql-experimental"] }
+arrow = { version = "39.0.0" }
+arrow-flight = { version = "39.0.0", features = ["flight-sql-experimental"] }
 configure_me = { version = "0.4.0" }
 configure_me_codegen = { version = "0.4.4" }
-datafusion = "24.0.0"
-datafusion-cli = "24.0.0"
-datafusion-proto = "24.0.0"
+datafusion = "25.0.0"
+datafusion-cli = "25.0.0"
+datafusion-proto = "25.0.0"
 object_store = "0.5.6"
 sqlparser = "0.33.0"
 tonic = { version = "0.9" }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

[VTX-1125]

 # Rationale for this change
In order to bring in additions for timestamp and interval arithmetic in Datafusion

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
https://github.com/apache/arrow-datafusion/blob/main/dev/changelog/25.0.0.md

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->


[VTX-1125]: https://coralogix.atlassian.net/browse/VTX-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ