### PR TITLE
VTX-1684: Update JobOverview

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -978,6 +978,18 @@ message Job {
   uint32 completed_tasks = 5;
 }
 
+message JobOverview {
+  string job_id = 1;
+  string job_name = 2;
+  JobStatus status = 3;
+  uint64 queued_at = 4;
+  uint64 start_time = 5;
+  uint64 end_time = 6;
+  uint32 num_stages = 7;
+  uint32 completed_stages = 8;
+  uint64 total_task_duration_ms = 9;
+}
+
 message ListJobsResponse {
   repeated Job running_jobs = 1;
 }

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1860,6 +1860,28 @@ pub struct Job {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct JobOverview {
+    #[prost(string, tag = "1")]
+    pub job_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub job_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub status: ::core::option::Option<JobStatus>,
+    #[prost(uint64, tag = "4")]
+    pub queued_at: u64,
+    #[prost(uint64, tag = "5")]
+    pub start_time: u64,
+    #[prost(uint64, tag = "6")]
+    pub end_time: u64,
+    #[prost(uint32, tag = "7")]
+    pub num_stages: u32,
+    #[prost(uint32, tag = "8")]
+    pub completed_stages: u32,
+    #[prost(uint64, tag = "9")]
+    pub total_task_duration_ms: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListJobsResponse {
     #[prost(message, repeated, tag = "1")]
     pub running_jobs: ::prost::alloc::vec::Vec<Job>,

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -119,8 +119,8 @@ pub(crate) async fn get_jobs<T: AsLogicalPlan, U: AsExecutionPlan>(
     let jobs: Vec<JobResponse> = jobs
         .iter()
         .map(|job| {
-            let status = &job.status;
-            let job_status = match &status.status {
+            let status = &job.status.as_ref().and_then(|s| s.status.as_ref());
+            let job_status = match status {
                 Some(Status::Queued(_)) => "Queued".to_string(),
                 Some(Status::Running(_)) => "Running".to_string(),
                 Some(Status::Failed(error)) => format!("Failed: {:?}", error.error),
@@ -156,8 +156,8 @@ pub(crate) async fn get_jobs<T: AsLogicalPlan, U: AsExecutionPlan>(
                 job_id: job.job_id.to_string(),
                 job_name: job.job_name.to_string(),
                 job_status,
-                num_stages: job.num_stages,
-                completed_stages: job.completed_stages,
+                num_stages: job.num_stages as usize,
+                completed_stages: job.completed_stages as usize,
                 percent_complete,
             }
         })

--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -20,7 +20,7 @@ use crate::cluster::{
     reserve_slots_bias, reserve_slots_round_robin, ClusterState, ExecutorHeartbeatStream,
     JobState, JobStateEvent, JobStateEventStream, JobStatus, TaskDistribution,
 };
-use crate::scheduler_server::{timestamp_secs, SessionBuilder};
+use crate::scheduler_server::{timestamp_millis, timestamp_secs, SessionBuilder};
 use crate::state::execution_graph::ExecutionGraph;
 use crate::state::executor_manager::ExecutorReservation;
 use crate::state::session_manager::create_datafusion_context;
@@ -636,7 +636,7 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                     }),
                     queued_at,
                     started_at: 0,
-                    ended_at: 0,
+                    ended_at: timestamp_millis(),
                 })),
             };
 

--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -621,12 +621,15 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
     async fn fail_unscheduled_job(
         &self,
         job_id: &str,
+        job_name: &str,
+        queued_at: u64,
         reason: Arc<BallistaError>,
     ) -> Result<()> {
-        if let Some((job_id, (job_name, queued_at))) = self.queued_jobs.remove(job_id) {
+        if self.queued_jobs.remove(job_id).is_some() {
+            let job_id = job_id.to_string();
             let status = JobStatus {
                 job_id: job_id.clone(),
-                job_name,
+                job_name: job_name.to_string(),
                 status: Some(Status::Failed(FailedJob {
                     error: Some(ExecutionError {
                         error: Some(reason.as_ref().into()),

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -465,15 +465,18 @@ impl JobState for InMemoryJobState {
     async fn fail_unscheduled_job(
         &self,
         job_id: &str,
+        job_name: &str,
+        queued_at: u64,
         reason: Arc<BallistaError>,
     ) -> Result<()> {
-        if let Some((job_id, (job_name, queued_at))) = self.queued_jobs.remove(job_id) {
+        if self.queued_jobs.remove(job_id).is_some() {
+            let job_id = job_id.to_string();
             self.completed_jobs.insert(
                 job_id.clone(),
                 (
                     JobStatus {
                         job_id,
-                        job_name,
+                        job_name: job_name.to_string(),
                         status: Some(Status::Failed(FailedJob {
                             error: Some(ExecutionError {
                                 error: Some(reason.as_ref().into()),

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -302,7 +302,7 @@ impl JobState for InMemoryJobState {
         if self.queued_jobs.get(job_id).is_some() {
             let job_id_owned = job_id.to_owned();
             self.running_jobs
-                .insert(job_id_owned.clone(), graph.status());
+                .insert(job_id_owned.clone(), graph.clone());
             self.queued_jobs.remove(job_id);
 
             self.job_event_sender.send(&JobStateEvent::JobAcquired {

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -298,13 +298,15 @@ impl InMemoryJobState {
 
 #[async_trait]
 impl JobState for InMemoryJobState {
-    async fn submit_job(&self, job_id: String, graph: &ExecutionGraph) -> Result<()> {
-        if self.queued_jobs.get(&job_id).is_some() {
-            self.running_jobs.insert(job_id.clone(), graph.status());
-            self.queued_jobs.remove(&job_id);
+    async fn submit_job(&self, job_id: &str, graph: &ExecutionGraph) -> Result<()> {
+        if self.queued_jobs.get(job_id).is_some() {
+            let job_id_owned = job_id.to_owned();
+            self.running_jobs
+                .insert(job_id_owned.clone(), graph.status());
+            self.queued_jobs.remove(job_id);
 
             self.job_event_sender.send(&JobStateEvent::JobAcquired {
-                job_id,
+                job_id: job_id_owned,
                 owner: self.scheduler.clone(),
             });
 

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -354,6 +354,8 @@ pub trait JobState: Send + Sync {
     async fn fail_unscheduled_job(
         &self,
         job_id: &str,
+        job_name: &str,
+        queued_at: u64,
         reason: Arc<BallistaError>,
     ) -> Result<()>;
 

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -328,7 +328,7 @@ pub trait JobState: Send + Sync {
     /// Submit a new job to the `JobState`. It is assumed that the submitter owns the job.
     /// In local state the job should be save as `JobStatus::Active` and in shared state
     /// it should be saved as `JobStatus::Running` with `scheduler` set to the current scheduler
-    async fn submit_job(&self, job_id: String, graph: &ExecutionGraph) -> Result<()>;
+    async fn submit_job(&self, job_id: &str, graph: &ExecutionGraph) -> Result<()>;
 
     /// Return a `HashSet` of all active job IDs in the `JobState`
     async fn get_jobs(&self) -> Result<HashSet<String>>;

--- a/ballista/scheduler/src/cluster/test/mod.rs
+++ b/ballista/scheduler/src/cluster/test/mod.rs
@@ -432,6 +432,8 @@ impl<S: JobState> JobStateTest<S> {
         self.state
             .fail_unscheduled_job(
                 job_id,
+                "name",
+                0,
                 Arc::new(BallistaError::Internal("failed planning".to_string())),
             )
             .await?;

--- a/ballista/scheduler/src/cluster/test/mod.rs
+++ b/ballista/scheduler/src/cluster/test/mod.rs
@@ -458,9 +458,7 @@ impl<S: JobState> JobStateTest<S> {
     }
 
     pub async fn submit_job(self, graph: &ExecutionGraph) -> Result<Self> {
-        self.state
-            .submit_job(graph.job_id().to_string(), graph)
-            .await?;
+        self.state.submit_job(graph.job_id(), graph).await?;
         Ok(self)
     }
 

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -46,6 +46,7 @@ pub enum QueryStageSchedulerEvent {
     // For a job which failed during planning
     JobPlanningFailed {
         job_id: String,
+        job_name: String,
         fail_message: String,
         queued_at: u64,
         failed_at: u64,

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -46,6 +46,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
+use crate::state::task_manager::JobOverviewExt;
 use datafusion::prelude::SessionContext;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tonic::{Request, Response, Status};
@@ -628,8 +629,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                         id: job_overview.job_id.clone(),
                         durations_ms,
                         total_task_duration_ms: job_overview.total_task_duration_ms,
-                        total_tasks: job_overview.num_stages as u32,
-                        completed_tasks: job_overview.completed_stages as u32,
+                        total_tasks: job_overview.num_stages,
+                        completed_tasks: job_overview.completed_stages,
                     })
                 }
 

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -102,6 +102,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
                         let fail_message = format!("Error planning job {job_id}: {e:?}");
                         QueryStageSchedulerEvent::JobPlanningFailed {
                             job_id,
+                            job_name,
                             fail_message,
                             queued_at,
                             failed_at: timestamp_millis(),
@@ -144,6 +145,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
             }
             QueryStageSchedulerEvent::JobPlanningFailed {
                 job_id,
+                job_name,
                 fail_message,
                 queued_at,
                 failed_at,
@@ -155,7 +157,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
                 error!(job_id, fail_message,%error,"job planning failed");
                 self.state
                     .task_manager
-                    .fail_unscheduled_job(&job_id, error)
+                    .fail_unscheduled_job(&job_id, &job_name, queued_at, error)
                     .await?;
             }
             QueryStageSchedulerEvent::JobFinished {

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -683,9 +683,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     pub async fn fail_unscheduled_job(
         &self,
         job_id: &str,
+        job_name: &str,
+        queued_at: u64,
         job_error: Arc<BallistaError>,
     ) -> Result<()> {
-        self.state.fail_unscheduled_job(job_id, job_error).await
+        self.state
+            .fail_unscheduled_job(job_id, job_name, queued_at, job_error)
+            .await
     }
 
     pub async fn update_job(&self, job_id: &str) -> Result<usize> {

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -889,6 +889,25 @@ impl JobOverview {
     pub fn is_running(&self) -> bool {
         matches!(self.status.status, Some(Status::Running(_)))
     }
+
+    pub fn queued(
+        job_id: String,
+        job_name: String,
+        status: JobStatus,
+        queued_at: u64,
+    ) -> Self {
+        Self {
+            job_id,
+            job_name,
+            status,
+            queued_at,
+            start_time: 0,
+            end_time: 0,
+            num_stages: 0,
+            completed_stages: 0,
+            total_task_duration_ms: 0,
+        }
+    }
 }
 
 impl From<&ExecutionGraph> for JobOverview {

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -435,7 +435,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             job_name, session_id, "submitting execution graph: {:?}", graph
         );
 
-        self.state.submit_job(job_id.to_string(), &graph).await?;
+        self.state.submit_job(job_id, &graph).await?;
 
         graph.revive();
         self.active_job_queue.push(job_id.to_owned(), graph);


### PR DESCRIPTION
Generally, we would like to be able to store `JobOverview` in Redis, so I moved the definition to proto, to exploit serialization later in DQE

Minor:
- update `submit_job` method signature
- add more useful info to `fail_unscheduled_job` to avoid additional lookup