### PR TITLE
upgrade to arrow-rs with take support for unions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ exclude = ["python"]
 members = ["ballista-cli", "ballista/client", "ballista/core", "ballista/executor", "ballista/scheduler", "ballista/tests", "benchmarks", "examples"]
 
 [workspace.dependencies]
-arrow = {version = "43.0.0"}
-arrow-flight = {version = "43.0.0", features = ["flight-sql-experimental"]}
-arrow-schema = {version = "43.0.0", default-features = false}
+arrow = { git = "https://github.com/coralogix/arrow-rs.git", tag = "v43.0.0-cx.1" }
+arrow-flight = { git = "https://github.com/coralogix/arrow-rs.git", tag = "v43.0.0-cx.1", features = ["flight-sql-experimental"]}
+arrow-schema = { git = "https://github.com/coralogix/arrow-rs.git", tag = "v43.0.0-cx.1", default-features = false}
 configure_me = {version = "0.4.0"}
 configure_me_codegen = {version = "0.4.4"}
-datafusion = { version = "28.0.0", features = ["avro"] } 
-datafusion-cli = "28.0.0"
-datafusion-proto = "28.0.0"
+datafusion = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v28.0.0-cx.13", features = ["avro"] }
+datafusion-cli = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v28.0.0-cx.13" }
+datafusion-proto = { git = "https://github.com/coralogix/arrow-datafusion.git", tag = "v28.0.0-cx.13" }
 object_store = "0.6.1"
 sqlparser = "0.35.0"
 tonic = {version = "0.9"}

--- a/ballista/core/src/plugin/mod.rs
+++ b/ballista/core/src/plugin/mod.rs
@@ -40,6 +40,7 @@ pub trait Plugin {
 }
 
 /// The enum of Plugin
+#[repr(C)]
 #[derive(PartialEq, std::cmp::Eq, std::hash::Hash, Copy, Clone)]
 pub enum PluginEnum {
     /// UDF/UDAF plugin

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -151,12 +151,24 @@ impl TryInto<protobuf::OperatorMetric> for &MetricValue {
             }),
             MetricValue::StartTimestamp(timestamp) => Ok(protobuf::OperatorMetric {
                 metric: Some(operator_metric::Metric::StartTimestamp(
-                    timestamp.value().map(|m| m.timestamp_nanos()).unwrap_or(0),
+                    timestamp
+                        .value()
+                        .map(|m| {
+                            m.timestamp_nanos_opt()
+                                .expect("value can't be represented in nanos")
+                        })
+                        .unwrap_or(0),
                 )),
             }),
             MetricValue::EndTimestamp(timestamp) => Ok(protobuf::OperatorMetric {
                 metric: Some(operator_metric::Metric::EndTimestamp(
-                    timestamp.value().map(|m| m.timestamp_nanos()).unwrap_or(0),
+                    timestamp
+                        .value()
+                        .map(|m| {
+                            m.timestamp_nanos_opt()
+                                .expect("value can't be represented in nanos")
+                        })
+                        .unwrap_or(0),
                 )),
             }),
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4883. (in arrow-rs)

 # Rationale for this change

Users want to be able to sort RecordBatches with Unions in them.

# What changes are included in this PR?

Ability to sort RecordBatches with Unions.

# Are there any user-facing changes?

Sorting with Unions should work.
