### PR TITLE
Revert noisy spans

### DIFF
--- a/ballista/core/src/execution_plans/coalesce_tasks.rs
+++ b/ballista/core/src/execution_plans/coalesce_tasks.rs
@@ -37,9 +37,7 @@ use std::any::Any;
 use std::sync::Arc;
 use std::task::Poll;
 use tokio::sync::mpsc;
-use tracing::span;
 use tracing::Instrument;
-use tracing::Level;
 
 #[derive(Debug, Clone)]
 pub struct CoalesceTasksExec {
@@ -137,13 +135,6 @@ impl ExecutionPlan for CoalesceTasksExec {
         // are sent to the channel for consumption.
         let mut join_handles = Vec::with_capacity(input_partitions);
         for partition in self.partitions.iter().copied() {
-            let _span = span!(
-                Level::INFO,
-                "coalesce_tasks partition",
-                partition = partition
-            )
-            .entered();
-
             let input = self.input.clone();
             let context = context.clone();
             let output = sender.clone();


### PR DESCRIPTION
[VTX-2935]

This is creating too many spans, making traces unusable 

[VTX-2935]: https://coralogix.atlassian.net/browse/VTX-2935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ