### PR TITLE
Enable flight stream lz4 compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["ballista-cli", "ballista/client", "ballista/core", "ballista/executo
 resolver = "2"
 
 [workspace.dependencies]
-arrow = { git = "https://github.com/Coralogix/arrow-rs.git", tag="v48.0.0-cx.0" }
+arrow = { git = "https://github.com/Coralogix/arrow-rs.git", tag="v48.0.0-cx.0", features=['ipc_compression'] }
 arrow-flight = { git = "https://github.com/Coralogix/arrow-rs.git", tag="v48.0.0-cx.0", features=["flight-sql-experimental"] }
 arrow-schema = { git = "https://github.com/Coralogix/arrow-rs.git", tag="v48.0.0-cx.0" }
 configure_me = { version = "0.4.0" }


### PR DESCRIPTION
So`FetchPartition` will use lz4 compression instead of sending the data uncompressed.

Should also reduce the chance we send a batch bigger than the max message size (even though there is no guarantee for e.g. huge rows).