### PR TITLE
Cache executor client by host:port

### DIFF
--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -66,7 +66,7 @@ pub struct ExecutorMetadata {
 
 impl ExecutorMetadata {
     pub fn endpoint(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        format!("{}:{}", self.host, self.grpc_port)
     }
 }
 

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -64,6 +64,12 @@ pub struct ExecutorMetadata {
     pub specification: ExecutorSpecification,
 }
 
+impl ExecutorMetadata {
+    pub fn endpoint(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
 /// Specification of an executor, indicting executor resources, like total task slots
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct ExecutorSpecification {


### PR DESCRIPTION
- Cache executor client by host:port
- Remove executor client when deregistering executor