### PR TITLE
VTX-3322 Register executor version

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -330,6 +330,7 @@ message ExecutorResource {
   // TODO add more resources
   oneof resource {
     uint32 task_slots = 1;
+    string version = 2;
   }
 }
 

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -546,7 +546,10 @@ mod tests {
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification { task_slots: 1 },
+                    specification: ExecutorSpecification {
+                        task_slots: 1,
+                        version: "".to_string(),
+                    },
                 },
                 partition_stats: Default::default(),
                 path: "test_path".to_string(),
@@ -667,7 +670,10 @@ mod tests {
                     host: "localhost".to_string(),
                     port: 50051,
                     grpc_port: 50052,
-                    specification: ExecutorSpecification { task_slots: 12 },
+                    specification: ExecutorSpecification {
+                        task_slots: 12,
+                        version: "0".to_string(),
+                    },
                 },
                 partition_stats: Default::default(),
                 path: path.clone(),

--- a/ballista/core/src/physical_optimizer/task_group.rs
+++ b/ballista/core/src/physical_optimizer/task_group.rs
@@ -234,7 +234,7 @@ mod tests {
                     host: "".into(),
                     port: 0,
                     grpc_port: 0,
-                    specification: ExecutorSpecification { task_slots: 0 },
+                    specification: ExecutorSpecification { task_slots: 0, version: "0".to_string() },
                 },
                 partition_stats: PartitionStats {
                     num_rows: None,

--- a/ballista/core/src/physical_optimizer/task_group.rs
+++ b/ballista/core/src/physical_optimizer/task_group.rs
@@ -234,7 +234,10 @@ mod tests {
                     host: "".into(),
                     port: 0,
                     grpc_port: 0,
-                    specification: ExecutorSpecification { task_slots: 0, version: "0".to_string() },
+                    specification: ExecutorSpecification {
+                        task_slots: 0,
+                        version: "0".to_string(),
+                    },
                 },
                 partition_stats: PartitionStats {
                     num_rows: None,

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -570,7 +570,7 @@ pub struct ExecutorSpecification {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorResource {
     /// TODO add more resources
-    #[prost(oneof = "executor_resource::Resource", tags = "1")]
+    #[prost(oneof = "executor_resource::Resource", tags = "1, 2")]
     pub resource: ::core::option::Option<executor_resource::Resource>,
 }
 /// Nested message and enum types in `ExecutorResource`.
@@ -581,6 +581,8 @@ pub mod executor_resource {
     pub enum Resource {
         #[prost(uint32, tag = "1")]
         TaskSlots(u32),
+        #[prost(string, tag = "2")]
+        Version(::prost::alloc::string::String),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -33,6 +33,7 @@ use crate::serde::scheduler::{
 
 use crate::serde::protobuf;
 use protobuf::{operator_metric, NamedCount, NamedGauge, NamedTime};
+use crate::serde::protobuf::executor_resource::Resource;
 
 impl TryInto<Action> for protobuf::Action {
     type Error = BallistaError;
@@ -215,15 +216,19 @@ impl Into<ExecutorMetadata> for protobuf::ExecutorMetadata {
 #[allow(clippy::from_over_into)]
 impl Into<ExecutorSpecification> for protobuf::ExecutorSpecification {
     fn into(self) -> ExecutorSpecification {
-        let mut ret = ExecutorSpecification { task_slots: 0 };
-        for resource in self.resources {
-            if let Some(protobuf::executor_resource::Resource::TaskSlots(task_slots)) =
-                resource.resource
-            {
-                ret.task_slots = task_slots
+        let mut task_slots = 0;
+        let mut version = "0".to_string();
+
+        for exec_resource in self.resources {
+            if let Some(resource) = exec_resource.resource {
+                match resource {
+                    Resource::TaskSlots(tasks) => task_slots = tasks,
+                    Resource::Version(v) => version = v,
+                }
             }
         }
-        ret
+
+        ExecutorSpecification { task_slots, version }
     }
 }
 

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -32,8 +32,8 @@ use crate::serde::scheduler::{
 };
 
 use crate::serde::protobuf;
-use protobuf::{operator_metric, NamedCount, NamedGauge, NamedTime};
 use crate::serde::protobuf::executor_resource::Resource;
+use protobuf::{operator_metric, NamedCount, NamedGauge, NamedTime};
 
 impl TryInto<Action> for protobuf::Action {
     type Error = BallistaError;
@@ -228,7 +228,10 @@ impl Into<ExecutorSpecification> for protobuf::ExecutorSpecification {
             }
         }
 
-        ExecutorSpecification { task_slots, version }
+        ExecutorSpecification {
+            task_slots,
+            version,
+        }
     }
 }
 

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -68,12 +68,16 @@ impl ExecutorMetadata {
     pub fn endpoint(&self) -> String {
         format!("http://{}:{}", self.host, self.grpc_port)
     }
+    pub fn version(&self) -> String {
+        self.specification.version.clone()
+    }
 }
 
 /// Specification of an executor, indicting executor resources, like total task slots
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExecutorSpecification {
     pub task_slots: u32,
+    pub version: String,
 }
 
 /// From Spark, available resources for an executor, like available task slots

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -204,9 +204,10 @@ impl Into<protobuf::ExecutorMetadata> for ExecutorMetadata {
 impl Into<protobuf::ExecutorSpecification> for ExecutorSpecification {
     fn into(self) -> protobuf::ExecutorSpecification {
         protobuf::ExecutorSpecification {
-            resources: vec![protobuf::executor_resource::Resource::TaskSlots(
-                self.task_slots,
-            )]
+            resources: vec![
+                protobuf::executor_resource::Resource::TaskSlots(self.task_slots),
+                protobuf::executor_resource::Resource::Version(self.version),
+            ]
             .into_iter()
             .map(|r| protobuf::ExecutorResource { resource: Some(r) })
             .collect(),

--- a/ballista/executor/executor_config_spec.toml
+++ b/ballista/executor/executor_config_spec.toml
@@ -109,6 +109,11 @@ type = "String"
 doc = "Log dir: a path to save log. This will create a new storage directory at the specified path if it does not already exist."
 
 [[param]]
+name = "executor_version"
+type = "String"
+doc = "Set the executor's version to be reported to the scheduler"
+
+[[param]]
 name = "print_thread_info"
 type = "bool"
 doc = "Enable print thread ids and names in log file."

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -65,6 +65,7 @@ async fn main() -> Result<()> {
         bind_host: opt.bind_host,
         port: opt.bind_port,
         grpc_port: opt.bind_grpc_port,
+        version: opt.executor_version,
         scheduler_host: opt.scheduler_host,
         scheduler_port: opt.scheduler_port,
         scheduler_connect_timeout_seconds: opt.scheduler_connect_timeout_seconds,

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -177,7 +177,9 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
             .map(executor_registration::OptionalHost::Host),
         port: opt.port as u32,
         grpc_port: opt.grpc_port as u32,
-        specification: Some(ExecutorSpecification { resources }),
+        specification: Some(ExecutorSpecification {
+            resources: resources.clone(),
+        }),
     };
 
     let config = with_object_store_provider(
@@ -365,11 +367,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
                         .map(executor_registration::OptionalHost::Host),
                     port: opt.port as u32,
                     grpc_port: opt.grpc_port as u32,
-                    specification: Some(ExecutorSpecification {
-                        resources: vec![ExecutorResource {
-                            resource: Some(Resource::TaskSlots(concurrent_tasks as u32)),
-                        }],
-                    }),
+                    specification: Some(ExecutorSpecification { resources }),
                 }),
             })
             .await

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -72,6 +72,7 @@ pub struct ExecutorProcessConfig {
     pub external_host: Option<String>,
     pub port: u16,
     pub grpc_port: u16,
+    pub version: Option<String>,
     pub scheduler_host: String,
     pub scheduler_port: u16,
     pub scheduler_connect_timeout_seconds: u16,
@@ -159,6 +160,15 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
     info!("concurrent_tasks: {}", concurrent_tasks);
     info!("executor_id: {}", executor_id);
 
+    let mut resources = vec![ExecutorResource {
+        resource: Some(Resource::TaskSlots(concurrent_tasks as u32)),
+    }];
+    if let Some(version) = opt.version {
+        resources.push(ExecutorResource {
+            resource: Some(Resource::Version(version.to_string())),
+        });
+    }
+
     let executor_meta = ExecutorRegistration {
         id: executor_id.clone(),
         optional_host: opt
@@ -167,11 +177,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
             .map(executor_registration::OptionalHost::Host),
         port: opt.port as u32,
         grpc_port: opt.grpc_port as u32,
-        specification: Some(ExecutorSpecification {
-            resources: vec![ExecutorResource {
-                resource: Some(Resource::TaskSlots(concurrent_tasks as u32)),
-            }],
-        }),
+        specification: Some(ExecutorSpecification { resources }),
     };
 
     let config = with_object_store_provider(

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -63,6 +63,7 @@ pub async fn new_standalone_executor<
         specification: Some(
             ExecutorSpecification {
                 task_slots: concurrent_tasks as u32,
+                version: "0".to_string(),
             }
             .into(),
         ),

--- a/ballista/scheduler/benches/scheduler_events.rs
+++ b/ballista/scheduler/benches/scheduler_events.rs
@@ -342,7 +342,10 @@ async fn setup_env(
             host: "127.0.0.1".to_string(),
             port: 7799,
             grpc_port: 7799,
-            specification: ExecutorSpecification { task_slots: 10 },
+            specification: ExecutorSpecification {
+                task_slots: 10,
+                version: "bench-1.0".to_string(),
+            },
         };
 
         let executor_data = ExecutorData {

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -729,7 +729,13 @@ mod test {
             optional_host: Some(OptionalHost::Host("http://localhost:8080".to_owned())),
             port: 0,
             grpc_port: 0,
-            specification: Some(ExecutorSpecification { task_slots: 2 }.into()),
+            specification: Some(
+                ExecutorSpecification {
+                    task_slots: 2,
+                    version: "".to_string(),
+                }
+                .into(),
+            ),
         };
         let request: Request<PollWorkParams> = Request::new(PollWorkParams {
             metadata: Some(exec_meta.clone()),
@@ -816,7 +822,13 @@ mod test {
             optional_host: Some(OptionalHost::Host("http://localhost:8080".to_owned())),
             port: 0,
             grpc_port: 0,
-            specification: Some(ExecutorSpecification { task_slots: 2 }.into()),
+            specification: Some(
+                ExecutorSpecification {
+                    task_slots: 2,
+                    version: "".to_string(),
+                }
+                .into(),
+            ),
         };
 
         let request: Request<RegisterExecutorParams> =
@@ -904,7 +916,13 @@ mod test {
             optional_host: Some(OptionalHost::Host("http://localhost:8080".to_owned())),
             port: 0,
             grpc_port: 0,
-            specification: Some(ExecutorSpecification { task_slots: 2 }.into()),
+            specification: Some(
+                ExecutorSpecification {
+                    task_slots: 2,
+                    version: "".to_string(),
+                }
+                .into(),
+            ),
         };
 
         let request: Request<HeartBeatParams> = Request::new(HeartBeatParams {
@@ -956,7 +974,13 @@ mod test {
             optional_host: Some(OptionalHost::Host("http://localhost:8080".to_owned())),
             port: 0,
             grpc_port: 0,
-            specification: Some(ExecutorSpecification { task_slots: 2 }.into()),
+            specification: Some(
+                ExecutorSpecification {
+                    task_slots: 2,
+                    version: "".to_string(),
+                }
+                .into(),
+            ),
         };
 
         let request: Request<RegisterExecutorParams> =

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -796,7 +796,10 @@ mod test {
                     host: "localhost1".to_string(),
                     port: 8080,
                     grpc_port: 9090,
-                    specification: ExecutorSpecification { task_slots },
+                    specification: ExecutorSpecification {
+                        task_slots,
+                        version: "".to_string(),
+                    },
                 },
                 ExecutorData {
                     executor_id: "executor-1".to_owned(),
@@ -812,6 +815,7 @@ mod test {
                     grpc_port: 9090,
                     specification: ExecutorSpecification {
                         task_slots: num_partitions as u32 - task_slots,
+                        version: "".to_string(),
                     },
                 },
                 ExecutorData {

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -764,6 +764,7 @@ mod test {
                     grpc_port: 9090,
                     specification: ExecutorSpecification {
                         task_slots: slots_per_executor,
+                        version: "".to_string(),
                     },
                 },
                 ExecutorData {

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -326,8 +326,10 @@ impl ExecutorManager {
         test_connection: bool,
     ) -> Result<Vec<ExecutorReservation>> {
         debug!(
-            "registering executor {} with {} task slots",
-            metadata.id, specification.total_task_slots
+            "registering executor {} at version {} with {} task slots",
+            metadata.id,
+            metadata.version(),
+            specification.total_task_slots
         );
 
         if test_connection {

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -621,6 +621,7 @@ mod test {
                     grpc_port: 9090,
                     specification: ExecutorSpecification {
                         task_slots: slots_per_executor,
+                        version: "".to_string(),
                     },
                 },
                 ExecutorData {

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -471,6 +471,7 @@ impl SchedulerTest {
                 grpc_port: 0,
                 specification: ExecutorSpecification {
                     task_slots: task_slots as u32,
+                    version: "0".to_string(),
                 },
             };
 
@@ -1056,7 +1057,7 @@ pub fn mock_executor(executor_id: String) -> ExecutorMetadata {
         host: "localhost2".to_string(),
         port: 8080,
         grpc_port: 9090,
-        specification: ExecutorSpecification { task_slots: 1 },
+        specification: ExecutorSpecification { task_slots: 1, version: "0".to_string() },
     }
 }
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -1057,7 +1057,10 @@ pub fn mock_executor(executor_id: String) -> ExecutorMetadata {
         host: "localhost2".to_string(),
         port: 8080,
         grpc_port: 9090,
-        specification: ExecutorSpecification { task_slots: 1, version: "0".to_string() },
+        specification: ExecutorSpecification {
+            task_slots: 1,
+            version: "0".to_string(),
+        },
     }
 }
 

--- a/ballista/tests/src/lib.rs
+++ b/ballista/tests/src/lib.rs
@@ -269,9 +269,14 @@ mod tests {
 
         for i in 0..n {
             let specification = ExecutorSpecification {
-                resources: vec![ExecutorResource {
-                    resource: Some(Resource::TaskSlots(1)),
-                }],
+                resources: vec![
+                    ExecutorResource {
+                        resource: Some(Resource::TaskSlots(1)),
+                    },
+                    ExecutorResource {
+                        resource: Some(Resource::Version("test".to_string())),
+                    },
+                ],
             };
 
             let port = 50051 + i as u32;


### PR DESCRIPTION
# Which issue does this PR close?

Introducing version-aware schedulers. Executors can be registered with a version string.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
