### PR TITLE
Add labels to circuit breaker

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -88,6 +88,7 @@ message ExecutionGraph {
   uint64 end_time = 12;
   uint64 queued_at = 13;
   bool circuit_breaker_tripped = 14;
+  repeated string circuit_breaker_tripped_labels = 15;
 }
 
 message StageAttempts {
@@ -539,6 +540,7 @@ message SuccessfulJob {
   uint64 started_at = 3;
   uint64 ended_at = 4;
   bool circuit_breaker_tripped = 5;
+  repeated string circuit_breaker_tripped_labels = 6;
 }
 
 message QueuedJob {
@@ -958,11 +960,17 @@ message CircuitBreakerTaskKey {
 message CircuitBreakerUpdateRequest {
   repeated CircuitBreakerUpdate updates = 1;
   string executor_id = 2;
+  repeated CircuitBreakerLabelsRegistration label_registrations = 3;
 }
 
 message CircuitBreakerUpdate {
   CircuitBreakerTaskKey key = 1;
   double percent = 2;
+}
+
+message CircuitBreakerLabelsRegistration {
+  CircuitBreakerTaskKey key = 1;
+  repeated string labels = 2;
 }
 
 message CircuitBreakerUpdateResponse {

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -114,6 +114,10 @@ pub struct ExecutionGraph {
     pub queued_at: u64,
     #[prost(bool, tag = "14")]
     pub circuit_breaker_tripped: bool,
+    #[prost(string, repeated, tag = "15")]
+    pub circuit_breaker_tripped_labels: ::prost::alloc::vec::Vec<
+        ::prost::alloc::string::String,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -943,6 +947,10 @@ pub struct SuccessfulJob {
     pub ended_at: u64,
     #[prost(bool, tag = "5")]
     pub circuit_breaker_tripped: bool,
+    #[prost(string, repeated, tag = "6")]
+    pub circuit_breaker_tripped_labels: ::prost::alloc::vec::Vec<
+        ::prost::alloc::string::String,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1838,6 +1846,8 @@ pub struct CircuitBreakerUpdateRequest {
     pub updates: ::prost::alloc::vec::Vec<CircuitBreakerUpdate>,
     #[prost(string, tag = "2")]
     pub executor_id: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub label_registrations: ::prost::alloc::vec::Vec<CircuitBreakerLabelsRegistration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1846,6 +1856,14 @@ pub struct CircuitBreakerUpdate {
     pub key: ::core::option::Option<CircuitBreakerTaskKey>,
     #[prost(double, tag = "2")]
     pub percent: f64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CircuitBreakerLabelsRegistration {
+    #[prost(message, optional, tag = "1")]
+    pub key: ::core::option::Option<CircuitBreakerTaskKey>,
+    #[prost(string, repeated, tag = "2")]
+    pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/executor/src/circuit_breaker/stream.rs
+++ b/ballista/executor/src/circuit_breaker/stream.rs
@@ -32,9 +32,11 @@ impl CircuitBreakerStream {
         calculate: Box<dyn CircuitBreakerCalculation + Send>,
         key: CircuitBreakerTaskKey,
         client: Arc<CircuitBreakerClient>,
+        labels: Vec<String>,
     ) -> Result<Self, Error> {
         let mut noop = false;
-        let circuit_breaker = match client.register(key.stage_key.clone()) {
+
+        let circuit_breaker = match client.register(key.clone(), labels) {
             Ok(circuit_breaker) => circuit_breaker,
             Err(e) => {
                 error!("Failed to register circuit breaker: {:?}", e);
@@ -80,6 +82,12 @@ impl CircuitBreakerStream {
 
 pub trait CircuitBreakerCalculation {
     fn calculate_delta(&mut self, poll: &Poll<Option<Result<RecordBatch>>>) -> f64;
+}
+
+#[derive(Debug)]
+pub struct CircuitBreakerLabelsRegistration {
+    pub key: CircuitBreakerTaskKey,
+    pub labels: Vec<String>,
 }
 
 #[derive(Debug)]

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -76,6 +76,7 @@ pub enum QueryStageSchedulerEvent {
     CircuitBreakerTripped {
         job_id: String,
         stage_id: usize,
+        labels: Vec<String>,
     },
 }
 

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -334,10 +334,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
                     );
                 }
             }
-            QueryStageSchedulerEvent::CircuitBreakerTripped { job_id, stage_id } => {
+            QueryStageSchedulerEvent::CircuitBreakerTripped {
+                job_id,
+                stage_id,
+                labels,
+            } => {
                 self.state
                     .task_manager
-                    .trip_circuit_breaker(job_id, stage_id)
+                    .trip_circuit_breaker(job_id, stage_id, labels)
                     .await;
             }
         }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -401,6 +401,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         })?;
 
         let plan = session_ctx.state().create_physical_plan(plan).await?;
+
         debug!(
             "Physical plan: {}",
             DisplayableExecutionPlan::new(plan.as_ref()).indent(false)

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -883,10 +883,15 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         }
     }
 
-    pub async fn trip_circuit_breaker(&self, job_id: String, stage_id: usize) {
+    pub async fn trip_circuit_breaker(
+        &self,
+        job_id: String,
+        stage_id: usize,
+        labels: Vec<String>,
+    ) {
         if let Some(job) = self.active_job_queue.get_job(&job_id) {
             let mut graph = job.graph_mut().await;
-            graph.trip_stage(stage_id);
+            graph.trip_stage(stage_id, labels);
         }
     }
 }

--- a/ballista/tests/src/lib.rs
+++ b/ballista/tests/src/lib.rs
@@ -144,11 +144,22 @@ mod tests {
 
         let job_id = result.into_inner().job_id;
 
-        let successful_job = await_job_completion(&mut scheduler_client, &job_id)
+        let mut successful_job = await_job_completion(&mut scheduler_client, &job_id)
             .await
             .unwrap();
 
         assert!(successful_job.circuit_breaker_tripped);
+
+        successful_job.circuit_breaker_tripped_labels.sort();
+
+        assert_eq!(
+            successful_job.circuit_breaker_tripped_labels,
+            vec![
+                "partition-0".to_owned(),
+                "partition-1".to_owned(),
+                "test".to_owned()
+            ]
+        );
 
         let partitions = successful_job.partition_location;
 

--- a/ballista/tests/src/test_table_exec.rs
+++ b/ballista/tests/src/test_table_exec.rs
@@ -141,8 +141,11 @@ impl ExecutionPlan for TestTableExec {
             let calc = Box::new(TestCalculation { limit })
                 as Box<dyn CircuitBreakerCalculation + Send>;
 
-            let limited_stream = CircuitBreakerStream::new(boxed, calc, key, client)
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            let labels = vec!["test".to_owned(), format!("partition-{}", partition)];
+
+            let limited_stream =
+                CircuitBreakerStream::new(boxed, calc, key, client, labels)
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
             return Ok(Box::pin(limited_stream));
         }


### PR DESCRIPTION
Add labels that can be defined during registration of a task with circuit breaker. This way, one can later determine which circuit breaker was tripped by looking at the job status.