### PR TITLE
VTX-3411: do not write empty batches

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -470,7 +470,7 @@ fn send_fetch_partitions(
                 .with_label_values(&["local"])
                 .inc();
             let now = Instant::now();
-            let result = PartitionReaderEnum::FlightRemote.fetch_partition(&p).await;
+            let result = PartitionReaderEnum::Local.fetch_partition(&p).await;
             SHUFFLE_READER_FETCH_PARTITION_LATENCY
                 .with_label_values(&["local"])
                 .observe(now.elapsed().as_secs_f64());


### PR DESCRIPTION
During monitoring async replication I discovered that we're creating a lot of empty batches/files. I think with this simple check we can reduce the amount of useless work