### PR TITLE
Configurable stage preemption in circuit breaker

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -947,7 +947,7 @@ message RunningTaskInfo {
   uint32 stage_id = 3;
 }
 
-message CircuitBreakerStageKey {
+message CircuitBreakerStateKey {
   string job_id = 1;
   uint32 stage_id = 2;
   uint32 attempt_num = 3;
@@ -955,7 +955,7 @@ message CircuitBreakerStageKey {
 }
 
 message CircuitBreakerTaskKey {
-  CircuitBreakerStageKey stage_key = 1;
+  CircuitBreakerStateKey state_key = 1;
   uint32 partition = 3;
   string task_id = 4;
 }
@@ -963,7 +963,7 @@ message CircuitBreakerTaskKey {
 message CircuitBreakerUpdateRequest {
   repeated CircuitBreakerUpdate updates = 1;
   string executor_id = 2;
-  repeated CircuitBreakerLabelsRegistration label_registrations = 3;
+  repeated CircuitBreakerStateConfiguration state_configurations = 3;
 }
 
 message CircuitBreakerUpdate {
@@ -971,9 +971,10 @@ message CircuitBreakerUpdate {
   double percent = 2;
 }
 
-message CircuitBreakerLabelsRegistration {
+message CircuitBreakerStateConfiguration {
   CircuitBreakerTaskKey key = 1;
   repeated string labels = 2;
+  bool preempt_stage = 3;
 }
 
 message CircuitBreakerUpdateResponse {
@@ -981,7 +982,7 @@ message CircuitBreakerUpdateResponse {
 }
 
 message CircuitBreakerCommand {
-  CircuitBreakerStageKey key = 1;
+  CircuitBreakerStateKey key = 1;
 }
 
 message SchedulerLostParams {

--- a/ballista/core/src/circuit_breaker/model.rs
+++ b/ballista/core/src/circuit_breaker/model.rs
@@ -1,16 +1,16 @@
 use crate::serde::protobuf;
 
 #[derive(Eq, PartialEq, Hash, Debug, Clone)]
-pub struct CircuitBreakerStageKey {
+pub struct CircuitBreakerStateKey {
     pub job_id: String,
     pub shared_state_id: String,
     pub stage_id: u32,
     pub attempt_num: u32,
 }
 
-impl From<CircuitBreakerStageKey> for protobuf::CircuitBreakerStageKey {
-    fn from(val: CircuitBreakerStageKey) -> Self {
-        protobuf::CircuitBreakerStageKey {
+impl From<CircuitBreakerStateKey> for protobuf::CircuitBreakerStateKey {
+    fn from(val: CircuitBreakerStateKey) -> Self {
+        protobuf::CircuitBreakerStateKey {
             job_id: val.job_id,
             stage_id: val.stage_id,
             attempt_num: val.attempt_num,
@@ -19,8 +19,8 @@ impl From<CircuitBreakerStageKey> for protobuf::CircuitBreakerStageKey {
     }
 }
 
-impl From<protobuf::CircuitBreakerStageKey> for CircuitBreakerStageKey {
-    fn from(key: protobuf::CircuitBreakerStageKey) -> Self {
+impl From<protobuf::CircuitBreakerStateKey> for CircuitBreakerStateKey {
+    fn from(key: protobuf::CircuitBreakerStateKey) -> Self {
         Self {
             job_id: key.job_id,
             stage_id: key.stage_id,
@@ -32,7 +32,7 @@ impl From<protobuf::CircuitBreakerStageKey> for CircuitBreakerStageKey {
 
 #[derive(Eq, PartialEq, Hash, Debug, Clone)]
 pub struct CircuitBreakerTaskKey {
-    pub stage_key: CircuitBreakerStageKey,
+    pub state_key: CircuitBreakerStateKey,
     pub partition: u32,
     pub task_id: String,
 }
@@ -40,7 +40,7 @@ pub struct CircuitBreakerTaskKey {
 impl From<CircuitBreakerTaskKey> for protobuf::CircuitBreakerTaskKey {
     fn from(val: CircuitBreakerTaskKey) -> Self {
         protobuf::CircuitBreakerTaskKey {
-            stage_key: Some(val.stage_key.into()),
+            state_key: Some(val.state_key.into()),
             partition: val.partition,
             task_id: val.task_id,
         }
@@ -51,8 +51,8 @@ impl TryFrom<protobuf::CircuitBreakerTaskKey> for CircuitBreakerTaskKey {
     type Error = String;
     fn try_from(key: protobuf::CircuitBreakerTaskKey) -> Result<Self, String> {
         Ok(Self {
-            stage_key: key
-                .stage_key
+            state_key: key
+                .state_key
                 .ok_or_else(|| {
                     "Circuit breaker task key contains no stage key".to_owned()
                 })?

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1825,7 +1825,7 @@ pub struct RunningTaskInfo {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CircuitBreakerStageKey {
+pub struct CircuitBreakerStateKey {
     #[prost(string, tag = "1")]
     pub job_id: ::prost::alloc::string::String,
     #[prost(uint32, tag = "2")]
@@ -1839,7 +1839,7 @@ pub struct CircuitBreakerStageKey {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerTaskKey {
     #[prost(message, optional, tag = "1")]
-    pub stage_key: ::core::option::Option<CircuitBreakerStageKey>,
+    pub state_key: ::core::option::Option<CircuitBreakerStateKey>,
     #[prost(uint32, tag = "3")]
     pub partition: u32,
     #[prost(string, tag = "4")]
@@ -1853,7 +1853,7 @@ pub struct CircuitBreakerUpdateRequest {
     #[prost(string, tag = "2")]
     pub executor_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "3")]
-    pub label_registrations: ::prost::alloc::vec::Vec<CircuitBreakerLabelsRegistration>,
+    pub state_configurations: ::prost::alloc::vec::Vec<CircuitBreakerStateConfiguration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1865,11 +1865,13 @@ pub struct CircuitBreakerUpdate {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CircuitBreakerLabelsRegistration {
+pub struct CircuitBreakerStateConfiguration {
     #[prost(message, optional, tag = "1")]
     pub key: ::core::option::Option<CircuitBreakerTaskKey>,
     #[prost(string, repeated, tag = "2")]
     pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(bool, tag = "3")]
+    pub preempt_stage: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1881,7 +1883,7 @@ pub struct CircuitBreakerUpdateResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CircuitBreakerCommand {
     #[prost(message, optional, tag = "1")]
-    pub key: ::core::option::Option<CircuitBreakerStageKey>,
+    pub key: ::core::option::Option<CircuitBreakerStateKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/executor/src/circuit_breaker/stream.rs
+++ b/ballista/executor/src/circuit_breaker/stream.rs
@@ -33,10 +33,11 @@ impl CircuitBreakerStream {
         key: CircuitBreakerTaskKey,
         client: Arc<CircuitBreakerClient>,
         labels: Vec<String>,
+        preempt_stage: bool,
     ) -> Result<Self, Error> {
         let mut noop = false;
 
-        let circuit_breaker = match client.register(key.clone(), labels) {
+        let circuit_breaker = match client.register(key.clone(), labels, preempt_stage) {
             Ok(circuit_breaker) => circuit_breaker,
             Err(e) => {
                 error!("Failed to register circuit breaker: {:?}", e);
@@ -85,9 +86,10 @@ pub trait CircuitBreakerCalculation {
 }
 
 #[derive(Debug)]
-pub struct CircuitBreakerLabelsRegistration {
+pub struct CircuitBreakerStateConfiguration {
     pub key: CircuitBreakerTaskKey,
     pub labels: Vec<String>,
+    pub preempt_stage: bool,
 }
 
 #[derive(Debug)]

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -77,6 +77,7 @@ pub enum QueryStageSchedulerEvent {
         job_id: String,
         stage_id: usize,
         labels: Vec<String>,
+        preempt_stage: bool,
     },
 }
 

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -328,11 +328,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
                 job_id,
                 stage_id,
                 labels,
+                preempt_stage,
             } => {
                 let events = self
                     .state
                     .task_manager
-                    .trip_circuit_breaker(job_id, stage_id, labels)
+                    .trip_circuit_breaker(job_id, stage_id, labels, preempt_stage)
                     .await?;
 
                 for event in events {

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1449,9 +1449,14 @@ impl ExecutionGraph {
         &mut self,
         stage_id: usize,
         labels: Vec<String>,
+        preempt: bool,
     ) -> Result<Vec<QueryStageSchedulerEvent>> {
         self.circuit_breaker_tripped = true;
         self.circuit_breaker_tripped_labels.extend(labels);
+
+        if !preempt {
+            return Ok(vec![]);
+        }
 
         let task_id = self.next_task_id() as u32;
 

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -855,10 +855,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         job_id: String,
         stage_id: usize,
         labels: Vec<String>,
+        preempty_stage: bool,
     ) -> Result<Vec<QueryStageSchedulerEvent>> {
         if let Some(job) = self.active_job_queue.get_job(&job_id) {
             let mut graph = job.graph_mut().await;
-            graph.trip_stage(stage_id, labels)
+            graph.trip_stage(stage_id, labels, preempty_stage)
         } else {
             Ok(vec![])
         }


### PR DESCRIPTION
We do not want to preempt the stage (mark all pending tasks as completed) in case of circuit breaker used for limit execs, only when it is used to enforce a scan limit. So I've made it configurable.

Also rename `...StageKey` stuff to `...StateKey` because we have a state ID there, too, so there are possibly several different ones per stage.

[VTX-4079]

[VTX-4079]: https://coralogix.atlassian.net/browse/VTX-4079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ