### PR TITLE
VTX-3411: skip empty files more aggressively, wrap not found an error

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -247,15 +247,21 @@ impl ShuffleWriterExec {
                         stats
                     );
 
-                    if let Some(sender) = sender.as_ref() {
-                        let cmd = replicator::Command::Replicate {
-                            job_id: job_id.clone(),
-                            path: path.to_string(),
-                            created,
-                        };
+                    if stats.num_rows.is_some_and(|v| v > 0) {
+                        if let Some(sender) = sender.as_ref() {
+                            let cmd = replicator::Command::Replicate {
+                                job_id: job_id.clone(),
+                                path: path.to_string(),
+                                created,
+                            };
 
-                        if let Err(error) = sender.send(cmd).await {
-                            warn!(?path, ?error, "Failed to send path for replication");
+                            if let Err(error) = sender.send(cmd).await {
+                                warn!(
+                                    ?path,
+                                    ?error,
+                                    "Failed to send path for replication"
+                                );
+                            }
                         }
                     }
 

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -197,15 +197,16 @@ pub async fn write_stream_to_disk(
 
     while let Some(result) = stream.next().await {
         let batch = result?;
+        if batch.num_rows() > 0 {
+            let batch_size_bytes: usize = batch.get_array_memory_size();
+            num_batches += 1;
+            num_rows += batch.num_rows();
+            num_bytes += batch_size_bytes;
 
-        let batch_size_bytes: usize = batch.get_array_memory_size();
-        num_batches += 1;
-        num_rows += batch.num_rows();
-        num_bytes += batch_size_bytes;
-
-        let timer = disk_write_metric.timer();
-        writer.write(&batch)?;
-        timer.done();
+            let timer = disk_write_metric.timer();
+            writer.write(&batch)?;
+            timer.done();
+        }
     }
     let timer = disk_write_metric.timer();
     writer.finish()?;

--- a/ballista/executor/src/replicator/mod.rs
+++ b/ballista/executor/src/replicator/mod.rs
@@ -511,9 +511,14 @@ mod tests {
         let destination: Path = Path::parse("2.data").unwrap();
 
         object_store.put(&destination, bytes).await?;
-        let stream =
-            batch_stream_from_object_store("id".to_string(), &destination, object_store)
-                .await?;
+        let stream = batch_stream_from_object_store(
+            "id".to_string(),
+            &destination,
+            0,
+            &[],
+            object_store,
+        )
+        .await?;
 
         let mut stream: SendableRecordBatchStream =
             Box::pin(RecordBatchStreamAdapter::new(stream.schema(), stream));


### PR DESCRIPTION
[VTX-3411]

More aggressive skipping of empty files for replication, special handling in case of s3 key not found error

[VTX-3411]: https://coralogix.atlassian.net/browse/VTX-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ