### PR TITLE
VTX-3411: skip empty partitions in shuffle reader

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -184,7 +184,11 @@ impl ExecutionPlan for ShuffleReaderExec {
         // Sort partitions for evenly send fetching partition requests to avoid hot executors within one task
         let mut partition_locations: Vec<PartitionLocation> = partition_locations
             .into_values()
-            .flat_map(|ps| ps.into_iter().enumerate())
+            .flat_map(|ps| {
+                ps.into_iter()
+                    .filter(|p| p.partition_stats.num_rows.map_or(true, |v| v > 0))
+                    .enumerate()
+            })
             .sorted_by(|(p1_idx, _), (p2_idx, _)| Ord::cmp(p1_idx, p2_idx))
             .map(|(_, p)| p)
             .collect();

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -195,6 +195,12 @@ impl ExecutionPlan for ShuffleReaderExec {
             .collect();
 
         if partition_locations.is_empty() {
+            info!(
+                task_id,
+                partition,
+                partition_location_count = self.partition[partition].len(),
+                "There are no partitions to fetch, returning an empty stream"
+            );
             return Ok(Box::pin(RecordBatchStreamAdapter::new(
                 self.schema(),
                 EmptyRecordBatchStream::new(self.schema()),


### PR DESCRIPTION
Skip empty partitions in the shuffle reader