### PR TITLE
Drop execution graph when job is completed

### DIFF
--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -346,11 +346,8 @@ impl JobState for InMemoryJobState {
         if let Some(graph) = self.running_jobs.get(job_id) {
             Ok(Some(graph.clone()))
         } else {
-            Ok(self
-                .completed_jobs
-                .get(job_id)
-                .as_deref()
-                .and_then(|(_, graph)| graph.clone()))
+            // We drop the `ExecutionGraph` after job is completed so always return `None` here
+            Ok(None)
         }
     }
 
@@ -370,8 +367,9 @@ impl JobState for InMemoryJobState {
             status.status,
             Some(Status::Successful(_)) | Some(Status::Failed(_))
         ) {
+            // Once job is completed, remove the `ExecutionGraph`
             self.completed_jobs
-                .insert(job_id.to_string(), (status, Some(graph.clone())));
+                .insert(job_id.to_string(), (status, None));
             self.running_jobs.remove(job_id);
         } else if let Some(old_status) =
             self.running_jobs.insert(job_id.to_string(), graph.clone())

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -482,7 +482,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         Ok(jobs)
     }
 
-    /// Get the status of of a job. First look in the active cache.
+    /// Get the status of a job. First look in the active cache.
     /// If no one found, then in the Active/Completed jobs, and then in Failed jobs
     pub async fn get_job_status(&self, job_id: &str) -> Result<Option<JobStatus>> {
         if let Some(graph) = self.get_active_execution_graph(job_id) {
@@ -505,9 +505,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
             Ok(Some(Arc::new(guard.deref().clone())))
         } else {
-            let graph = self.state.get_execution_graph(job_id).await?;
-
-            Ok(graph.map(Arc::new))
+            // We drop the `ExecutionGraph` after job is completed so always return `None` here
+            Ok(None)
         }
     }
 
@@ -632,12 +631,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     /// and remove the job from ActiveJobs
     pub(crate) async fn succeed_job(&self, job_id: &str) -> Result<()> {
         debug!(job_id, "completing job");
-
-        if let Some(graph) = self.remove_active_execution_graph(job_id) {
+        if let Some(graph) = self.get_active_execution_graph(job_id) {
             let graph = graph.read().await.clone();
 
             if graph.is_successful() {
                 self.state.save_job(job_id, &graph).await?;
+
+                // After state is saved, remove job from active cache
+                let _ = self.remove_active_execution_graph(job_id);
             } else {
                 error!(job_id, "cannot complete job, not finished");
                 return Ok(());


### PR DESCRIPTION
So we can keep completed jobs around for longer, we drop the `ExecutionGraph` once it's completed