### PR TITLE
VTX-4537: flight service update and more

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -64,6 +64,7 @@ message UnresolvedShuffleExecNode {
 message ShuffleReaderExecNode {
   repeated ShuffleReaderPartition partition = 1;
   datafusion.Schema schema = 2;
+  uint32 max_request_num = 3;
 }
 
 message ShuffleReaderPartition {
@@ -146,6 +147,7 @@ message UnResolvedStage {
   bytes plan = 5;
   uint32 stage_attempt_num = 6;
   repeated string last_attempt_failure_reasons = 7;
+  uint32 shuffle_reader_parallelism = 8;
 }
 
 message ResolvedStage {
@@ -158,6 +160,7 @@ message ResolvedStage {
   uint32 stage_attempt_num = 7;
   repeated string last_attempt_failure_reasons = 8;
   uint64 resolved_at = 9;
+  uint32 shuffle_reader_parallelism = 10;
 }
 
 message SuccessfulStage {
@@ -170,6 +173,7 @@ message SuccessfulStage {
   repeated TaskInfo task_infos = 7;
   repeated OperatorMetricsSet stage_metrics = 8;
   uint32 stage_attempt_num = 9;
+  uint32 shuffle_reader_parallelism = 10;
 }
 
 message FailedStage {

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -64,7 +64,7 @@ message UnresolvedShuffleExecNode {
 message ShuffleReaderExecNode {
   repeated ShuffleReaderPartition partition = 1;
   datafusion.Schema schema = 2;
-  uint32 shuffle_reader_parallelism = 3;
+  uint32 parallelism = 3;
 }
 
 message ShuffleReaderPartition {

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -64,7 +64,7 @@ message UnresolvedShuffleExecNode {
 message ShuffleReaderExecNode {
   repeated ShuffleReaderPartition partition = 1;
   datafusion.Schema schema = 2;
-  uint32 max_request_num = 3;
+  uint32 shuffle_reader_parallelism = 3;
 }
 
 message ShuffleReaderPartition {

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -75,7 +75,7 @@ lazy_static! {
             "ballista_shuffle_reader_fetch_partition_latency",
             "Fetch partition latency in seconds",
             &["type"],
-            vec![0.01, 0.03, 0.05, 0.1, 0.3, 0.5, 1.0, 3.0],
+            vec![0.01, 0.03, 0.05, 0.1, 0.3, 0.5, 1.0, 3.0, 9.0, 20.0],
         )
         .unwrap();
     static ref SHUFFLE_READER_FETCH_PARTITION_TOTAL: IntCounterVec =

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -98,7 +98,7 @@ pub struct ShuffleReaderExec {
     metrics: ExecutionPlanMetricsSet,
     object_store: Option<Arc<dyn ObjectStore>>,
     clients: Arc<Cache<String, BallistaClient>>,
-    pub shuffle_reader_parallelism: usize,
+    pub parallelism: usize,
 }
 
 impl ShuffleReaderExec {
@@ -108,7 +108,7 @@ impl ShuffleReaderExec {
         schema: SchemaRef,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
-        shuffle_reader_parallelism: usize,
+        parallelism: usize,
     ) -> Self {
         Self {
             partition,
@@ -116,7 +116,7 @@ impl ShuffleReaderExec {
             metrics: ExecutionPlanMetricsSet::new(),
             object_store,
             clients,
-            shuffle_reader_parallelism,
+            parallelism,
         }
     }
 }
@@ -222,7 +222,7 @@ impl ExecutionPlan for ShuffleReaderExec {
                 partition_locations,
                 object_store.clone(),
                 self.clients.clone(),
-                self.shuffle_reader_parallelism,
+                self.parallelism,
             )
         } else {
             send_fetch_partitions(
@@ -230,7 +230,7 @@ impl ExecutionPlan for ShuffleReaderExec {
                 partition,
                 partition_locations,
                 self.clients.clone(),
-                self.shuffle_reader_parallelism,
+                self.parallelism,
             )
         };
 
@@ -369,10 +369,10 @@ fn send_fetch_partitions_with_fallback(
 
     object_store: Arc<dyn ObjectStore>,
     clients: Arc<Cache<String, BallistaClient>>,
-    shuffle_reader_parallelism: usize,
+    parallelism: usize,
 ) -> AbortableReceiverStream {
-    let (response_sender, response_receiver) = mpsc::channel(shuffle_reader_parallelism);
-    let semaphore = Arc::new(Semaphore::new(shuffle_reader_parallelism));
+    let (response_sender, response_receiver) = mpsc::channel(parallelism);
+    let semaphore = Arc::new(Semaphore::new(parallelism));
     let mut join_handles = Vec::with_capacity(3);
     let (local_locations, remote_locations): (Vec<_>, Vec<_>) = partition_locations
         .into_iter()

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -512,11 +512,11 @@ fn send_fetch_partitions(
     partition: usize,
     partition_locations: Vec<PartitionLocation>,
     clients: Arc<Cache<String, BallistaClient>>,
-    shuffle_reader_parallelism: usize,
+    parallelism: usize,
 ) -> AbortableReceiverStream {
-    let (response_sender, response_receiver) = channel(shuffle_reader_parallelism);
+    let (response_sender, response_receiver) = channel(parallelism);
 
-    let semaphore = Arc::new(Semaphore::new(shuffle_reader_parallelism));
+    let semaphore = Arc::new(Semaphore::new(parallelism));
     let mut join_handles = Vec::with_capacity(2);
     let (local_locations, remote_locations): (Vec<_>, Vec<_>) = partition_locations
         .into_iter()

--- a/ballista/core/src/physical_optimizer/task_group.rs
+++ b/ballista/core/src/physical_optimizer/task_group.rs
@@ -260,6 +260,7 @@ mod tests {
             ])),
             None,
             Arc::new(Cache::new(10)),
+            50,
         ))
     }
 
@@ -338,6 +339,7 @@ mod tests {
             Arc::new(Schema::empty()),
             None,
             Arc::new(Cache::new(10)),
+            50,
         ));
 
         let optiized = optimizer.insert_coalesce(input).unwrap().into();

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -76,6 +76,8 @@ pub struct ShuffleReaderExecNode {
     pub partition: ::prost::alloc::vec::Vec<ShuffleReaderPartition>,
     #[prost(message, optional, tag = "2")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
+    #[prost(uint32, tag = "3")]
+    pub max_request_num: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -213,6 +215,8 @@ pub struct UnResolvedStage {
     pub last_attempt_failure_reasons: ::prost::alloc::vec::Vec<
         ::prost::alloc::string::String,
     >,
+    #[prost(uint32, tag = "8")]
+    pub shuffle_reader_parallelism: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -239,6 +243,8 @@ pub struct ResolvedStage {
     >,
     #[prost(uint64, tag = "9")]
     pub resolved_at: u64,
+    #[prost(uint32, tag = "10")]
+    pub shuffle_reader_parallelism: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -263,6 +269,8 @@ pub struct SuccessfulStage {
     pub stage_metrics: ::prost::alloc::vec::Vec<OperatorMetricsSet>,
     #[prost(uint32, tag = "9")]
     pub stage_attempt_num: u32,
+    #[prost(uint32, tag = "10")]
+    pub shuffle_reader_parallelism: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -77,7 +77,7 @@ pub struct ShuffleReaderExecNode {
     #[prost(message, optional, tag = "2")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
     #[prost(uint32, tag = "3")]
-    pub max_request_num: u32,
+    pub shuffle_reader_parallelism: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -77,7 +77,7 @@ pub struct ShuffleReaderExecNode {
     #[prost(message, optional, tag = "2")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
     #[prost(uint32, tag = "3")]
-    pub shuffle_reader_parallelism: u32,
+    pub parallelism: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -216,7 +216,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     schema,
                     self.object_store.clone(),
                     self.clients.clone(),
-                    shuffle_reader.max_request_num as usize,
+                    shuffle_reader.shuffle_reader_parallelism as usize,
                 );
                 Ok(Arc::new(shuffle_reader))
             }
@@ -327,7 +327,8 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     protobuf::ShuffleReaderExecNode {
                         partition,
                         schema: Some(exec.schema().as_ref().try_into()?),
-                        max_request_num: exec.shuffle_reader_parallelism as u32,
+                        shuffle_reader_parallelism: exec.shuffle_reader_parallelism
+                            as u32,
                     },
                 )),
             };

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -216,6 +216,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     schema,
                     self.object_store.clone(),
                     self.clients.clone(),
+                    shuffle_reader.max_request_num as usize,
                 );
                 Ok(Arc::new(shuffle_reader))
             }
@@ -326,6 +327,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     protobuf::ShuffleReaderExecNode {
                         partition,
                         schema: Some(exec.schema().as_ref().try_into()?),
+                        max_request_num: exec.shuffle_reader_parallelism as u32,
                     },
                 )),
             };

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -216,7 +216,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     schema,
                     self.object_store.clone(),
                     self.clients.clone(),
-                    shuffle_reader.shuffle_reader_parallelism as usize,
+                    shuffle_reader.parallelism as usize,
                 );
                 Ok(Arc::new(shuffle_reader))
             }
@@ -327,8 +327,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     protobuf::ShuffleReaderExecNode {
                         partition,
                         schema: Some(exec.schema().as_ref().try_into()?),
-                        shuffle_reader_parallelism: exec.shuffle_reader_parallelism
-                            as u32,
+                        parallelism: exec.parallelism as u32,
                     },
                 )),
             };

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -114,7 +114,7 @@ impl FlightService for BallistaFlightService {
             .map_err(from_arrow_err)?;
         let schema = reader.schema();
 
-        let (tx, rx) = channel(2);
+        let (tx, rx) = channel(10);
 
         let executor_id = self.executor_id.clone();
         task::spawn(async move {

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -18,15 +18,14 @@
 //! Implementation of the Apache Arrow Flight protocol that wraps an executor.
 
 use std::convert::TryFrom;
-use std::fs::File;
 use std::pin::Pin;
 
 use arrow::ipc::writer::IpcWriteOptions;
 use arrow::ipc::CompressionType;
+use ballista_core::async_reader::AsyncStreamReader;
 use ballista_core::serde::decode_protobuf;
 use ballista_core::serde::scheduler::Action as BallistaAction;
 
-use arrow::ipc::reader::StreamReader;
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
 use arrow_flight::{
@@ -35,12 +34,15 @@ use arrow_flight::{
     PutResult, SchemaResult, Ticket,
 };
 use datafusion::arrow::{error::ArrowError, record_batch::RecordBatch};
-use futures::{Stream, TryStreamExt};
-use std::io::{Read, Seek};
+use futures::io::BufReader;
+use futures::{AsyncRead, AsyncSeek, Stream, TryStreamExt};
+
+use tokio::fs::File;
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::error::SendError;
 use tokio::{sync::mpsc::Sender, task};
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 use tonic::metadata::MetadataValue;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{info, warn};
@@ -103,18 +105,22 @@ impl FlightService for BallistaFlightService {
             executor_id = self.executor_id,
             job_id, stage_id, partition, path, "fetching shuffle partition"
         );
-        let file = File::open(path.as_str()).map_err(|e| {
+        let file = File::open(path.as_str()).await.map_err(|e| {
             Status::internal(format!("Failed to open partition file at {path}: {e:?}"))
         })?;
 
-        let reader = StreamReader::try_new(file, None).map_err(from_arrow_err)?;
+        let mut reader = AsyncStreamReader::try_new(file.compat(), None)
+            .await
+            .map_err(from_arrow_err)?;
         let schema = reader.schema();
 
         let (tx, rx) = channel(2);
 
         let executor_id = self.executor_id.clone();
-        task::spawn_blocking(move || {
-            if let Err(e) = read_partition(job_id, stage_id, partition, reader, tx) {
+        task::spawn(async move {
+            if let Err(e) =
+                read_partition(job_id, stage_id, partition, &mut reader, tx).await
+            {
                 warn!(executor_id, error = %e, "error streaming shuffle partition");
             }
         });
@@ -209,15 +215,15 @@ impl FlightService for BallistaFlightService {
     }
 }
 
-fn read_partition<T>(
+async fn read_partition<T>(
     job_id: String,
     stage_id: usize,
     partition: usize,
-    reader: StreamReader<std::io::BufReader<T>>,
+    reader: &mut AsyncStreamReader<BufReader<T>>,
     tx: Sender<Result<RecordBatch, FlightError>>,
 ) -> Result<(), FlightError>
 where
-    T: Read + Seek,
+    T: Send + Unpin + AsyncRead + AsyncSeek,
 {
     if tx.is_closed() {
         return Err(FlightError::Tonic(Status::internal(
@@ -225,8 +231,9 @@ where
         )));
     }
 
-    for batch in reader {
-        tx.blocking_send(batch.map_err(|err| err.into()))
+    while let Some(batch) = reader.maybe_next().await.transpose() {
+        tx.send(batch.map_err(|err| err.into()))
+            .await
             .map_err(|err| {
                 if let SendError(Err(err)) = err {
                     err

--- a/ballista/scheduler/benches/scheduler_events.rs
+++ b/ballista/scheduler/benches/scheduler_events.rs
@@ -335,6 +335,7 @@ async fn setup_env(
         launcher,
         None,
         clients,
+        50,
     );
 
     server.init().await.unwrap();

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -127,6 +127,6 @@ async fn main() -> Result<()> {
     let cluster =
         BallistaCluster::new_from_config(&config, None, clients.clone()).await?;
 
-    start_server(cluster, addr, config, None, clients).await?;
+    start_server(cluster, addr, config, None, clients, 50).await?;
     Ok(())
 }

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -213,6 +213,7 @@ pub fn remove_unresolved_shuffles(
     partition_locations: &HashMap<usize, HashMap<usize, Vec<PartitionLocation>>>,
     object_store: Option<Arc<dyn ObjectStore>>,
     clients: Arc<Cache<String, BallistaClient>>,
+    shuffle_reader_parallelism: usize,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut new_children: Vec<Arc<dyn ExecutionPlan>> = vec![];
     for child in stage.children() {
@@ -255,6 +256,7 @@ pub fn remove_unresolved_shuffles(
                 unresolved_shuffle.schema().clone(),
                 object_store.clone(),
                 clients.clone(),
+                shuffle_reader_parallelism,
             )))
         } else {
             new_children.push(remove_unresolved_shuffles(
@@ -262,6 +264,7 @@ pub fn remove_unresolved_shuffles(
                 partition_locations,
                 object_store.clone(),
                 clients.clone(),
+                shuffle_reader_parallelism,
             )?);
         }
     }

--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -51,6 +51,7 @@ pub async fn start_server(
     config: SchedulerConfig,
     object_store: Option<Arc<dyn ObjectStore>>,
     clients: Arc<Cache<String, BallistaClient>>,
+    shuffle_reader_parallelism: usize,
 ) -> Result<()> {
     info!(
         "Ballista v{} Scheduler listening on {:?}",
@@ -77,6 +78,7 @@ pub async fn start_server(
             metrics_collector,
             object_store,
             clients,
+            shuffle_reader_parallelism,
         );
 
     scheduler_server.init().await?;

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -763,6 +763,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             );
         scheduler.init().await?;
         let exec_meta = ExecutorRegistration {
@@ -869,6 +870,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             );
         scheduler.init().await?;
 
@@ -969,6 +971,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             );
         scheduler.init().await?;
 
@@ -1033,6 +1036,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -85,6 +85,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         metrics_collector: Arc<dyn SchedulerMetricsCollector>,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         let state = Arc::new(SchedulerState::new(
             cluster,
@@ -94,6 +95,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             config.clone(),
             object_store,
             clients,
+            shuffle_reader_parallelism,
         ));
         let query_stage_scheduler = Arc::new(QueryStageScheduler::new(
             state.clone(),
@@ -128,6 +130,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         task_launcher: Arc<dyn TaskLauncher<T, U>>,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         let state = Arc::new(SchedulerState::new_with_task_launcher(
             cluster,
@@ -138,6 +141,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             task_launcher,
             object_store,
             clients,
+            shuffle_reader_parallelism,
         ));
         let query_stage_scheduler = Arc::new(QueryStageScheduler::new(
             state.clone(),
@@ -794,6 +798,7 @@ mod test {
                 Arc::new(TestMetricsCollector::default()),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -55,6 +55,7 @@ pub async fn new_standalone_scheduler_with_codec(
             metrics_collector,
             None,
             Arc::new(Cache::new(100)),
+            50,
         );
 
     scheduler_server.init().await?;

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -164,6 +164,7 @@ impl ExecutionGraph {
         object_store: Option<Arc<dyn ObjectStore>>,
         warnings: Vec<String>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Result<Self> {
         let mut planner = DistributedPlanner::new();
 
@@ -172,8 +173,19 @@ impl ExecutionGraph {
         let shuffle_stages = planner.plan_query_stages(job_id, plan)?;
 
         let builder = match object_store {
-            Some(object_store) => ExecutionStageBuilder::new(object_store, clients),
-            _ => ExecutionStageBuilder::default(),
+            Some(object_store) => ExecutionStageBuilder::new(
+                object_store,
+                clients,
+                shuffle_reader_parallelism,
+            ),
+            _ => ExecutionStageBuilder {
+                clients,
+                shuffle_reader_parallelism,
+                current_stage_id: 0,
+                stage_dependencies: HashMap::new(),
+                output_links: HashMap::new(),
+                object_store: None,
+            },
         };
         let stages = builder.build(shuffle_stages)?;
 
@@ -1610,24 +1622,14 @@ struct ExecutionStageBuilder {
     output_links: HashMap<usize, Vec<usize>>,
     object_store: Option<Arc<dyn ObjectStore>>,
     clients: Arc<Cache<String, BallistaClient>>,
-}
-
-impl Default for ExecutionStageBuilder {
-    fn default() -> Self {
-        Self {
-            current_stage_id: 0,
-            stage_dependencies: HashMap::new(),
-            output_links: HashMap::new(),
-            object_store: None,
-            clients: Arc::new(Cache::new(200)),
-        }
-    }
+    shuffle_reader_parallelism: usize,
 }
 
 impl ExecutionStageBuilder {
     pub fn new(
         object_store: Arc<dyn ObjectStore>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         Self {
             current_stage_id: 0,
@@ -1635,6 +1637,7 @@ impl ExecutionStageBuilder {
             output_links: HashMap::new(),
             object_store: Some(object_store),
             clients,
+            shuffle_reader_parallelism,
         }
     }
 
@@ -1670,6 +1673,7 @@ impl ExecutionStageBuilder {
                     HashSet::new(),
                     self.object_store.clone(),
                     self.clients.clone(),
+                    self.shuffle_reader_parallelism,
                 ))
             } else {
                 ExecutionStage::UnResolved(UnresolvedStage::new(
@@ -1680,6 +1684,7 @@ impl ExecutionStageBuilder {
                     child_stages,
                     self.object_store.clone(),
                     self.clients.clone(),
+                    self.shuffle_reader_parallelism,
                 ))
             };
             execution_stages.insert(stage_id, stage);

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -313,10 +313,8 @@ impl ExecutionGraph {
             .all(|s| matches!(s, ExecutionStage::Successful(_)))
     }
 
-    pub fn is_complete(&self) -> bool {
-        self.stages
-            .values()
-            .all(|s| matches!(s, ExecutionStage::Successful(_)))
+    pub fn is_failed(&self) -> bool {
+        matches!(self.status.status.as_ref(), Some(Status::Failed(_)))
     }
 
     /// Revive the execution graph by converting the resolved stages to running stages

--- a/ballista/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/scheduler/src/state/execution_graph_dot.rs
@@ -653,6 +653,7 @@ filter_expr="]
             None,
             vec![],
             Arc::new(Cache::new(100)),
+            50,
         )
     }
 
@@ -688,6 +689,7 @@ filter_expr="]
             None,
             vec![],
             Arc::new(Cache::new(100)),
+            50,
         )
     }
 }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -119,9 +119,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
             SchedulerConfig::default(),
             object_store,
             Arc::new(Cache::new(100)),
+            50,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         cluster: BallistaCluster,
         codec: BallistaCodec<T, U>,
@@ -130,6 +132,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         config: SchedulerConfig,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         Self {
             scheduler_version,
@@ -143,6 +146,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                 scheduler_name,
                 object_store,
                 clients,
+                shuffle_reader_parallelism,
             ),
             session_manager: SessionManager::new(cluster.job_state()),
             codec,
@@ -161,6 +165,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         dispatcher: Arc<dyn TaskLauncher<T, U>>,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         Self {
             scheduler_version,
@@ -174,6 +179,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                 dispatcher,
                 object_store,
                 clients,
+                shuffle_reader_parallelism,
             ),
             session_manager: SessionManager::new(cluster.job_state()),
             codec,
@@ -566,6 +572,7 @@ mod test {
                 Arc::new(BlackholeTaskLauncher::default()),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             ));
 
         let session_ctx = state

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -305,6 +305,7 @@ pub struct TaskManager<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
     check_drained: watch::Receiver<()>,
     object_store: Option<Arc<dyn ObjectStore>>,
     clients: Arc<Cache<String, BallistaClient>>,
+    shuffle_reader_parallelism: usize,
 }
 
 struct ExecutionGraphWriteGuard<'a> {
@@ -381,6 +382,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         scheduler_id: String,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         let launcher =
             DefaultTaskLauncher::new(scheduler_id.clone(), state.clone(), codec);
@@ -391,6 +393,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             Arc::new(launcher),
             object_store,
             clients,
+            shuffle_reader_parallelism,
         )
     }
 
@@ -401,6 +404,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         launcher: Arc<dyn TaskLauncher<T, U>>,
         object_store: Option<Arc<dyn ObjectStore>>,
         clients: Arc<Cache<String, BallistaClient>>,
+        shuffle_reader_parallelism: usize,
     ) -> Self {
         let (drained, check_drained) = watch::channel(());
 
@@ -413,6 +417,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             check_drained,
             object_store,
             clients,
+            shuffle_reader_parallelism,
         }
     }
 
@@ -459,6 +464,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             self.object_store.clone(),
             warnings,
             self.clients.clone(),
+            self.shuffle_reader_parallelism,
         )?;
         info!(
             job_id,

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -601,8 +601,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             if let Some(job_info) = self.active_job_queue.pop() {
                 let mut graph = job_info.graph_mut().await;
                 for (exec_id, slots) in free_reservations.iter_mut() {
-                    if slots.is_empty() {
-                        continue;
+                    if !graph.is_failed() {
+                        break;
                     }
 
                     if let Some(task) = graph.pop_next_task(exec_id, slots.len())? {

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -601,6 +601,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             if let Some(job_info) = self.active_job_queue.pop() {
                 let mut graph = job_info.graph_mut().await;
                 for (exec_id, slots) in free_reservations.iter_mut() {
+                    if slots.is_empty() {
+                        continue;
+                    }
+
                     if graph.is_failed() {
                         break;
                     }

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -601,7 +601,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             if let Some(job_info) = self.active_job_queue.pop() {
                 let mut graph = job_info.graph_mut().await;
                 for (exec_id, slots) in free_reservations.iter_mut() {
-                    if !graph.is_failed() {
+                    if graph.is_failed() {
                         break;
                     }
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -471,6 +471,7 @@ impl SchedulerTest {
                 Arc::new(launcher),
                 None,
                 Arc::new(Cache::new(100)),
+                50,
             );
         scheduler.init().await?;
 
@@ -891,6 +892,7 @@ pub async fn test_aggregation_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
+        50,
     )
     .unwrap()
 }
@@ -937,6 +939,7 @@ pub async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
+        50,
     )
     .unwrap()
 }
@@ -975,6 +978,7 @@ pub async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
+        50,
     )
     .unwrap()
 }
@@ -1034,6 +1038,7 @@ pub async fn test_join_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
+        50,
     )
     .unwrap();
 
@@ -1076,6 +1081,7 @@ pub async fn test_union_all_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
+        50,
     )
     .unwrap();
 
@@ -1118,6 +1124,7 @@ pub async fn test_union_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
+        50,
     )
     .unwrap();
 


### PR DESCRIPTION
Switching to async stream readers for `do_get` endpoint. Also increased flight-service stream return channel size, and added larger latency buckets

Exposed shuffle reader parallelism as a config param