### PR TITLE
VTX-4537: switch to async stream reader for local files, remove semaphore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tracing = "0.1.36"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 moka = { version = "0.12.5", features = ["future"] }
+tokio-util = { version = "0.7.10", features = ["compat"] }
 
 # cargo build --profile release-lto
 [profile.release-lto]

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -75,6 +75,7 @@ sqlparser = { workspace = true }
 sys-info = "0.9.0"
 tokio = "1.0"
 tokio-stream = { version = "0.1", features = ["net"] }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = "0.1.36"
 url = "2.2"

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -68,7 +68,7 @@ tokio = { version = "1.0", features = [
     "signal",
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tokio-util = { version = "0.7.10", features = ["compat"] }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = "0.1.36"
 tracing-appender = "0.2.2"


### PR DESCRIPTION
- Switched to async stream reader for local files
- use channel semaphore instead of an external one