### PR TITLE
VTX-4537: max request per ballista client

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -62,6 +62,7 @@ message UnresolvedShuffleExecNode {
 }
 message ShuffleReaderExecNodeOptions {
   uint32 partition_fetch_parallelism = 1;
+  uint32 max_request_per_client = 2;
 }
 message ShuffleReaderExecNode {
   repeated ShuffleReaderPartition partition = 1;

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -23,11 +23,8 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::error::{BallistaError, Result};
 use crate::serde::scheduler::Action;
-use crate::{
-    error::{BallistaError, Result},
-    serde::scheduler::{ExecutorMetadata, PartitionLocation},
-};
 
 use arrow_flight::decode::{DecodedPayload, FlightDataDecoder};
 use arrow_flight::error::FlightError;
@@ -62,23 +59,30 @@ impl LimitedBallistaClient {
         Ok(Self { client, semaphore })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn fetch_partition(
         &mut self,
-        metadata: &ExecutorMetadata,
-        location: &PartitionLocation,
+        executor_id: &str,
+        job_id: &str,
+        stage_id: usize,
+        output_partition: usize,
+        map_partitions: &[usize],
+        path: &str,
+        host: &str,
+        port: u16,
     ) -> Result<SendableRecordBatchStream> {
         let _ = self.semaphore.acquire().await.unwrap();
 
         self.client
             .fetch_partition(
-                &metadata.id,
-                &location.job_id,
-                location.stage_id,
-                location.output_partition,
-                &location.map_partitions,
-                &location.path,
-                &metadata.host,
-                metadata.port,
+                executor_id,
+                job_id,
+                stage_id,
+                output_partition,
+                map_partitions,
+                path,
+                host,
+                port,
             )
             .await
     }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -655,8 +655,18 @@ async fn fetch_partition_remote(
     let metadata = &location.executor_meta;
     let mut ballista_client =
         get_executor_client(clients, location, metadata, max_request_per_client).await?;
-
-    ballista_client.fetch_partition(metadata, location).await
+    ballista_client
+        .fetch_partition(
+            &metadata.id,
+            &location.job_id,
+            location.stage_id,
+            location.output_partition,
+            &location.map_partitions,
+            &location.path,
+            &metadata.host,
+            metadata.port,
+        )
+        .await
 }
 
 async fn fetch_partition_local(

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -74,6 +74,8 @@ pub struct UnresolvedShuffleExecNode {
 pub struct ShuffleReaderExecNodeOptions {
     #[prost(uint32, tag = "1")]
     pub partition_fetch_parallelism: u32,
+    #[prost(uint32, tag = "2")]
+    pub max_request_per_client: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -18,7 +18,7 @@
 //! This crate contains code generated from the Ballista Protocol Buffer Definition as well
 //! as convenience code for interacting with the generated code.
 
-use crate::client::BallistaClient;
+use crate::client::LimitedBallistaClient;
 use crate::{error::BallistaError, serde::scheduler::Action as BallistaAction};
 
 use arrow_flight::sql::ProstMessageExt;
@@ -94,7 +94,7 @@ pub struct BallistaCodec<
 impl BallistaCodec {
     pub fn new_with_object_store_and_clients(
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Self {
         Self {
             logical_extension_codec: Arc::new(DefaultLogicalExtensionCodec {}),
@@ -133,13 +133,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> BallistaCodec<T, 
 #[derive(Debug, Clone)]
 pub struct BallistaPhysicalExtensionCodec {
     pub object_store: Option<Arc<dyn ObjectStore>>,
-    pub clients: Arc<Cache<String, BallistaClient>>,
+    pub clients: Arc<Cache<String, LimitedBallistaClient>>,
 }
 
 impl BallistaPhysicalExtensionCodec {
     pub fn new(
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Self {
         Self {
             object_store,

--- a/ballista/scheduler/benches/scheduler_events.rs
+++ b/ballista/scheduler/benches/scheduler_events.rs
@@ -336,9 +336,7 @@ async fn setup_env(
         launcher,
         None,
         clients,
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     );
 
     server.init().await.unwrap();

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -134,9 +134,7 @@ async fn main() -> Result<()> {
         config,
         None,
         clients,
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .await?;
     Ok(())

--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -27,7 +27,7 @@ use crate::state::execution_graph::ExecutionGraph;
 use crate::state::executor_manager::ExecutorReservation;
 use crate::state::session_manager::create_datafusion_context;
 use async_trait::async_trait;
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::config::BallistaConfig;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::protobuf::job_status::Status;
@@ -79,7 +79,7 @@ pub struct KeyValueState<
     /// Default datafusion config extensions
     default_extensions: Extensions,
     object_store: Option<Arc<dyn ObjectStore>>,
-    clients: Arc<Cache<String, BallistaClient>>,
+    clients: Arc<Cache<String, LimitedBallistaClient>>,
 }
 
 impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
@@ -92,7 +92,7 @@ impl<S: KeyValueStore, T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         session_builder: SessionBuilder,
         default_extensions: Extensions,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Self {
         Self {
             store,

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use clap::ArgEnum;
 use datafusion::config::Extensions;
 use datafusion::prelude::SessionContext;
@@ -118,7 +118,7 @@ impl BallistaCluster {
         codec: BallistaCodec<T, U>,
         default_extensions: Extensions,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Self {
         let kv_state = Arc::new(KeyValueState::new(
             scheduler,
@@ -138,7 +138,7 @@ impl BallistaCluster {
     pub async fn new_from_config(
         config: &SchedulerConfig,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Result<Self> {
         let scheduler = config.scheduler_name();
 

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::execution_plans::ShuffleReaderExecOptions;
 use ballista_core::{
@@ -213,7 +213,7 @@ pub fn remove_unresolved_shuffles(
     stage: Arc<dyn ExecutionPlan>,
     partition_locations: &HashMap<usize, HashMap<usize, Vec<PartitionLocation>>>,
     object_store: Option<Arc<dyn ObjectStore>>,
-    clients: Arc<Cache<String, BallistaClient>>,
+    clients: Arc<Cache<String, LimitedBallistaClient>>,
     options: Arc<ShuffleReaderExecOptions>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut new_children: Vec<Arc<dyn ExecutionPlan>> = vec![];

--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -18,7 +18,7 @@
 use anyhow::{Context, Result};
 #[cfg(feature = "flight-sql")]
 use arrow_flight::flight_service_server::FlightServiceServer;
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::execution_plans::ShuffleReaderExecOptions;
 use futures::future::{self, Either, TryFutureExt};
 use hyper::{server::conn::AddrStream, service::make_service_fn, Server};
@@ -51,7 +51,7 @@ pub async fn start_server(
     addr: SocketAddr,
     config: SchedulerConfig,
     object_store: Option<Arc<dyn ObjectStore>>,
-    clients: Arc<Cache<String, BallistaClient>>,
+    clients: Arc<Cache<String, LimitedBallistaClient>>,
     shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 ) -> Result<()> {
     info!(

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -764,9 +764,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             );
         scheduler.init().await?;
         let exec_meta = ExecutorRegistration {
@@ -873,9 +871,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             );
         scheduler.init().await?;
 
@@ -976,9 +972,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             );
         scheduler.init().await?;
 
@@ -1043,9 +1037,7 @@ mod test {
                 default_metrics_collector().unwrap(),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::error::Result;
 use ballista_core::event_loop::{EventLoop, EventSender};
 use ballista_core::execution_plans::ShuffleReaderExecOptions;
@@ -85,7 +85,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         config: SchedulerConfig,
         metrics_collector: Arc<dyn SchedulerMetricsCollector>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         let state = Arc::new(SchedulerState::new(
@@ -130,7 +130,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         metrics_collector: Arc<dyn SchedulerMetricsCollector>,
         task_launcher: Arc<dyn TaskLauncher<T, U>>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         let state = Arc::new(SchedulerState::new_with_task_launcher(
@@ -800,9 +800,7 @@ mod test {
                 Arc::new(TestMetricsCollector::default()),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -56,9 +56,7 @@ pub async fn new_standalone_scheduler_with_codec(
             metrics_collector,
             None,
             Arc::new(Cache::new(100)),
-            Arc::new(ShuffleReaderExecOptions {
-                partition_fetch_parallelism: 50,
-            }),
+            Arc::new(ShuffleReaderExecOptions::default()),
         );
 
     scheduler_server.init().await?;

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -21,7 +21,7 @@ use std::fmt::{Debug, Formatter};
 use std::iter::FromIterator;
 use std::sync::Arc;
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::metrics::{MetricValue, MetricsSet};
 use datafusion::physical_plan::{
@@ -165,7 +165,7 @@ impl ExecutionGraph {
         queued_at: u64,
         object_store: Option<Arc<dyn ObjectStore>>,
         warnings: Vec<String>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Result<Self> {
         let mut planner = DistributedPlanner::new();
@@ -1332,7 +1332,7 @@ for (partition, status) in stage.task_infos
         codec: &BallistaCodec<T, U>,
         session_ctx: &SessionContext,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Result<ExecutionGraph> {
         let status = proto.status.ok_or_else(|| {
             BallistaError::Internal("Invalid Execution Graph".to_owned())
@@ -1617,14 +1617,14 @@ struct ExecutionStageBuilder {
     /// Map from Stage ID -> output link
     output_links: HashMap<usize, Vec<usize>>,
     object_store: Option<Arc<dyn ObjectStore>>,
-    clients: Arc<Cache<String, BallistaClient>>,
+    clients: Arc<Cache<String, LimitedBallistaClient>>,
     shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 }
 
 impl ExecutionStageBuilder {
     pub fn new(
         object_store: Arc<dyn ObjectStore>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         Self {

--- a/ballista/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_graph/execution_stage.rs
@@ -21,7 +21,7 @@ use std::fmt::{Debug, Formatter};
 use std::iter::FromIterator;
 use std::sync::Arc;
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::execution_plans::ShuffleReaderExecOptions;
 use datafusion::physical_optimizer::aggregate_statistics::AggregateStatistics;
 use datafusion::physical_optimizer::join_selection::JoinSelection;
@@ -140,7 +140,7 @@ pub(crate) struct UnresolvedStage {
 
     pub(crate) object_store: Option<Arc<dyn ObjectStore>>,
 
-    pub(crate) clients: Arc<Cache<String, BallistaClient>>,
+    pub(crate) clients: Arc<Cache<String, LimitedBallistaClient>>,
 
     pub(crate) shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 }
@@ -171,7 +171,7 @@ pub(crate) struct ResolvedStage {
     pub(crate) resolved_at: u64,
 
     pub(crate) object_store: Option<Arc<dyn ObjectStore>>,
-    pub(crate) clients: Arc<Cache<String, BallistaClient>>,
+    pub(crate) clients: Arc<Cache<String, LimitedBallistaClient>>,
     pub(crate) shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 }
 
@@ -208,7 +208,7 @@ pub(crate) struct RunningStage {
     /// Timestamp when then stage went into resolved state
     pub(crate) resolved_at: u64,
     pub(crate) object_store: Option<Arc<dyn ObjectStore>>,
-    pub(crate) clients: Arc<Cache<String, BallistaClient>>,
+    pub(crate) clients: Arc<Cache<String, LimitedBallistaClient>>,
     pub(crate) shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 }
 
@@ -237,7 +237,7 @@ pub(crate) struct SuccessfulStage {
     /// Combined metrics of the already finished tasks in the stage.
     pub(crate) stage_metrics: Vec<MetricsSet>,
     pub(crate) object_store: Option<Arc<dyn ObjectStore>>,
-    pub(crate) clients: Arc<Cache<String, BallistaClient>>,
+    pub(crate) clients: Arc<Cache<String, LimitedBallistaClient>>,
     pub(crate) shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 }
 
@@ -304,7 +304,7 @@ impl UnresolvedStage {
         output_links: Vec<usize>,
         child_stage_ids: Vec<usize>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         let mut inputs: HashMap<usize, StageOutput> = HashMap::new();
@@ -336,7 +336,7 @@ impl UnresolvedStage {
         inputs: HashMap<usize, StageOutput>,
         last_attempt_failure_reasons: HashSet<String>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         Self {
@@ -453,7 +453,7 @@ impl UnresolvedStage {
         codec: &BallistaCodec<T, U>,
         session_ctx: &SessionContext,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Result<UnresolvedStage> {
         let plan_proto = U::try_decode(&stage.plan)?;
         let plan = plan_proto.try_into_physical_plan(
@@ -547,7 +547,7 @@ impl ResolvedStage {
         inputs: HashMap<usize, StageOutput>,
         last_attempt_failure_reasons: HashSet<String>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         let partitions = plan.output_partitioning().partition_count();
@@ -609,7 +609,7 @@ impl ResolvedStage {
         codec: &BallistaCodec<T, U>,
         session_ctx: &SessionContext,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Result<ResolvedStage> {
         let plan_proto = U::try_decode(&stage.plan)?;
         let plan = plan_proto.try_into_physical_plan(
@@ -706,7 +706,7 @@ impl RunningStage {
         inputs: HashMap<usize, StageOutput>,
         resolved_at: u64,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         Self {
@@ -1073,7 +1073,7 @@ impl SuccessfulStage {
         codec: &BallistaCodec<T, U>,
         session_ctx: &SessionContext,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
     ) -> Result<SuccessfulStage> {
         let plan_proto = U::try_decode(&stage.plan)?;
         let plan = plan_proto.try_into_physical_plan(

--- a/ballista/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/scheduler/src/state/execution_graph_dot.rs
@@ -654,9 +654,7 @@ filter_expr="]
             None,
             vec![],
             Arc::new(Cache::new(100)),
-            Arc::new(ShuffleReaderExecOptions {
-                partition_fetch_parallelism: 50,
-            }),
+            Arc::new(ShuffleReaderExecOptions::default()),
         )
     }
 
@@ -692,9 +690,7 @@ filter_expr="]
             None,
             vec![],
             Arc::new(Cache::new(100)),
-            Arc::new(ShuffleReaderExecOptions {
-                partition_fetch_parallelism: 50,
-            }),
+            Arc::new(ShuffleReaderExecOptions::default()),
         )
     }
 }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::execution_plans::ShuffleReaderExecOptions;
 use ballista_core::warning_collector::WarningCollector;
 use datafusion::common::tree_node::{TreeNode, VisitRecursion};
@@ -120,9 +120,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
             SchedulerConfig::default(),
             object_store,
             Arc::new(Cache::new(100)),
-            Arc::new(ShuffleReaderExecOptions {
-                partition_fetch_parallelism: 50,
-            }),
+            Arc::new(ShuffleReaderExecOptions::default()),
         )
     }
 
@@ -134,7 +132,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         scheduler_version: String,
         config: SchedulerConfig,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         Self {
@@ -167,7 +165,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         config: SchedulerConfig,
         dispatcher: Arc<dyn TaskLauncher<T, U>>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         Self {
@@ -576,9 +574,7 @@ mod test {
                 Arc::new(BlackholeTaskLauncher::default()),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             ));
 
         let session_ctx = state

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -20,7 +20,7 @@ use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::state::execution_graph::{ExecutionGraph, RunningTaskInfo, TaskDescription};
 use crate::state::executor_manager::{ExecutorManager, ExecutorReservation};
 
-use ballista_core::client::BallistaClient;
+use ballista_core::client::LimitedBallistaClient;
 use ballista_core::error::BallistaError;
 use ballista_core::error::Result;
 use ballista_core::execution_plans::ShuffleReaderExecOptions;
@@ -305,7 +305,7 @@ pub struct TaskManager<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
     drained: Arc<watch::Sender<()>>,
     check_drained: watch::Receiver<()>,
     object_store: Option<Arc<dyn ObjectStore>>,
-    clients: Arc<Cache<String, BallistaClient>>,
+    clients: Arc<Cache<String, LimitedBallistaClient>>,
     shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
 }
 
@@ -382,7 +382,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         codec: BallistaCodec<T, U>,
         scheduler_id: String,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         let launcher =
@@ -404,7 +404,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         scheduler_id: String,
         launcher: Arc<dyn TaskLauncher<T, U>>,
         object_store: Option<Arc<dyn ObjectStore>>,
-        clients: Arc<Cache<String, BallistaClient>>,
+        clients: Arc<Cache<String, LimitedBallistaClient>>,
         shuffle_reader_options: Arc<ShuffleReaderExecOptions>,
     ) -> Self {
         let (drained, check_drained) = watch::channel(());

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -472,9 +472,7 @@ impl SchedulerTest {
                 Arc::new(launcher),
                 None,
                 Arc::new(Cache::new(100)),
-                Arc::new(ShuffleReaderExecOptions {
-                    partition_fetch_parallelism: 50,
-                }),
+                Arc::new(ShuffleReaderExecOptions::default()),
             );
         scheduler.init().await?;
 
@@ -895,9 +893,7 @@ pub async fn test_aggregation_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .unwrap()
 }
@@ -944,9 +940,7 @@ pub async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .unwrap()
 }
@@ -985,9 +979,7 @@ pub async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .unwrap()
 }
@@ -1047,9 +1039,7 @@ pub async fn test_join_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .unwrap();
 
@@ -1092,9 +1082,7 @@ pub async fn test_union_all_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .unwrap();
 
@@ -1137,9 +1125,7 @@ pub async fn test_union_plan(partition: usize) -> ExecutionGraph {
         None,
         vec![],
         Arc::new(Cache::new(100)),
-        Arc::new(ShuffleReaderExecOptions {
-            partition_fetch_parallelism: 50,
-        }),
+        Arc::new(ShuffleReaderExecOptions::default()),
     )
     .unwrap();
 


### PR DESCRIPTION
Introducing ballista client with an upper limit for the number of requests (per executor), even if we have N open files per flight service, we don't have any limitation on the number of requests sent by the client itself, so some clients may consume all capacity available on a service. By introducing a cap, I'm trying to make the ballista client more respectful of other kids on a block.

The proper number still needs to be selected empirically. In general, it should improve p99 latency, but decrease p95 (for how much?)