### PR TITLE
VTX-4537: control the real amount of concurrent streams

### DIFF
--- a/ballista/core/src/async_reader/mod.rs
+++ b/ballista/core/src/async_reader/mod.rs
@@ -306,10 +306,10 @@ impl<R: AsyncRead + Unpin + Send> Drop for AsyncStreamReader<R> {
         BALLISTA_ASYNC_STREAM_READER_LATENCY
             .with_label_values(&[self.metrics.label.as_str()])
             .observe(self.metrics.started_at.elapsed().as_secs_f64());
-        BALLISTA_ASYNC_STREAM_READER_CAPACITY
+        BALLISTA_ASYNC_STREAM_NUM_ROWS
             .with_label_values(&[self.metrics.label.as_str()])
             .inc_by(self.metrics.num_rows as f64);
-        BALLISTA_ASYNC_STREAM_READER_SIZE
+        BALLISTA_ASYNC_STREAM_DATA_SIZE
             .with_label_values(&[self.metrics.label.as_str()])
             .inc_by(self.metrics.size as f64);
     }

--- a/ballista/core/src/async_reader/mod.rs
+++ b/ballista/core/src/async_reader/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, fmt, mem::ManuallyDrop, sync::Arc};
 
 use async_stream::stream;
 use datafusion::{
@@ -21,7 +21,7 @@ use lazy_static::lazy_static;
 use prometheus::{
     register_counter_vec, register_histogram_vec, CounterVec, HistogramVec,
 };
-use tokio::time::Instant;
+use tokio::{sync::OwnedSemaphorePermit, time::Instant};
 
 const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
 
@@ -87,6 +87,7 @@ pub struct AsyncStreamReader<R: AsyncRead + Unpin + Send> {
     /// Optional projection
     projection: Option<(Vec<usize>, Schema)>,
     metrics: AsyncStreamReaderMetrics,
+    permit: ManuallyDrop<OwnedSemaphorePermit>,
 }
 
 impl<R: AsyncRead + Unpin + Send> fmt::Debug for AsyncStreamReader<R> {
@@ -109,6 +110,7 @@ impl<R: AsyncBufRead + Unpin + Send> AsyncStreamReader<R> {
         mut reader: R,
         projection: Option<Vec<usize>>,
         label: String,
+        permit: OwnedSemaphorePermit,
     ) -> Result<AsyncStreamReader<R>, ArrowError> {
         // determine metadata length
         let mut meta_size: [u8; 4] = [0; 4];
@@ -152,6 +154,7 @@ impl<R: AsyncBufRead + Unpin + Send> AsyncStreamReader<R> {
             dictionaries_by_id,
             projection,
             metrics,
+            permit: ManuallyDrop::new(permit),
         })
     }
 
@@ -296,8 +299,9 @@ impl<R: AsyncRead + Unpin + Send> AsyncStreamReader<BufReader<R>> {
         reader: R,
         projection: Option<Vec<usize>>,
         label: String,
+        permit: OwnedSemaphorePermit,
     ) -> Result<Self, ArrowError> {
-        Self::try_new_unbuffered(BufReader::new(reader), projection, label).await
+        Self::try_new_unbuffered(BufReader::new(reader), projection, label, permit).await
     }
 }
 
@@ -312,6 +316,7 @@ impl<R: AsyncRead + Unpin + Send> Drop for AsyncStreamReader<R> {
         BALLISTA_ASYNC_STREAM_DATA_SIZE
             .with_label_values(&[self.metrics.label.as_str()])
             .inc_by(self.metrics.size as f64);
+        unsafe { ManuallyDrop::drop(&mut self.permit) }
     }
 }
 
@@ -329,22 +334,24 @@ mod tests {
 
     #[tokio::test]
     async fn load_shuffle_file_a_lot() -> Result<(), DatafusionError> {
+        let semaphore = Arc::new(Semaphore::new(100));
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("tests/data.arrow");
         let mut handles = Vec::with_capacity(1000);
-        let semaphore = Arc::new(Semaphore::new(1000));
         for _ in 0..1000 {
             let path = path.clone();
             let sem = semaphore.clone();
             handles.push(tokio::spawn(async move {
-                let permit = sem.acquire().await.unwrap();
                 let file = File::open(path).await.unwrap();
-                let reader =
-                    AsyncStreamReader::try_new(file.compat(), None, "test".to_string())
-                        .await
-                        .unwrap();
+                let reader = AsyncStreamReader::try_new(
+                    file.compat(),
+                    None,
+                    "test".to_string(),
+                    sem.clone().acquire_owned().await.unwrap(),
+                )
+                .await
+                .unwrap();
                 let mut stream = reader.to_stream();
-                drop(permit);
                 let result = utils::collect_stream(&mut stream).await.unwrap();
                 !result.is_empty()
             }))

--- a/ballista/core/src/async_reader/mod.rs
+++ b/ballista/core/src/async_reader/mod.rs
@@ -18,7 +18,9 @@ use datafusion::{
 };
 use futures::{future::BoxFuture, io::BufReader, AsyncBufRead, AsyncRead, AsyncReadExt};
 use lazy_static::lazy_static;
-use prometheus::{register_histogram_vec, HistogramVec};
+use prometheus::{
+    register_counter_vec, register_histogram_vec, CounterVec, HistogramVec,
+};
 use tokio::time::Instant;
 
 const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
@@ -32,6 +34,36 @@ lazy_static! {
             vec![0.01, 0.03, 0.05, 0.1, 0.3, 0.5, 1.0, 3.0, 5.0, 9.0, 20.0]
         )
         .unwrap();
+    static ref BALLISTA_ASYNC_STREAM_READER_CAPACITY: CounterVec = register_counter_vec!(
+        "ballista_async_stream_reader_capacity",
+        "Ballista async stream reader capacity",
+        &["type"]
+    )
+    .unwrap();
+    static ref BALLISTA_ASYNC_STREAM_READER_SIZE: CounterVec = register_counter_vec!(
+        "ballista_async_stream_reader_size",
+        "Ballista async stream reader size",
+        &["type"]
+    )
+    .unwrap();
+}
+
+pub struct AsyncStreamReaderMetrics {
+    pub label: String,
+    pub started_at: Instant,
+    pub num_rows: usize,
+    pub size: usize,
+}
+
+impl AsyncStreamReaderMetrics {
+    pub fn new(label: String) -> Self {
+        Self {
+            label,
+            started_at: Instant::now(),
+            num_rows: 0,
+            size: 0,
+        }
+    }
 }
 
 /// Arrow Stream reader
@@ -54,8 +86,7 @@ pub struct AsyncStreamReader<R: AsyncRead + Unpin + Send> {
 
     /// Optional projection
     projection: Option<(Vec<usize>, Schema)>,
-    started_at: Instant,
-    label: String,
+    metrics: AsyncStreamReaderMetrics,
 }
 
 impl<R: AsyncRead + Unpin + Send> fmt::Debug for AsyncStreamReader<R> {
@@ -113,14 +144,14 @@ impl<R: AsyncBufRead + Unpin + Send> AsyncStreamReader<R> {
             }
             _ => None,
         };
+        let metrics = AsyncStreamReaderMetrics::new(label.clone());
         Ok(Self {
             reader,
             schema: Arc::new(schema),
             finished: false,
             dictionaries_by_id,
             projection,
-            started_at: Instant::now(),
-            label,
+            metrics,
         })
     }
 
@@ -194,7 +225,10 @@ impl<R: AsyncBufRead + Unpin + Send> AsyncStreamReader<R> {
                 let mut buf = MutableBuffer::from_len_zeroed(message.bodyLength() as usize);
                 self.reader.read_exact(&mut buf).await?;
 
-                read_record_batch(&buf.into(), batch, self.schema(), &self.dictionaries_by_id, self.projection.as_ref().map(|x| x.0.as_ref()), &message.version()).map(Some)
+                let batch = read_record_batch(&buf.into(), batch, self.schema(), &self.dictionaries_by_id, self.projection.as_ref().map(|x| x.0.as_ref()), &message.version())?;
+                self.metrics.num_rows += batch.num_rows();
+                self.metrics.size += batch.get_array_memory_size();
+                Ok(Some(batch))
             }
             MessageHeader::DictionaryBatch => {
                 let batch = message.header_as_dictionary_batch().ok_or_else(|| {
@@ -270,8 +304,14 @@ impl<R: AsyncRead + Unpin + Send> AsyncStreamReader<BufReader<R>> {
 impl<R: AsyncRead + Unpin + Send> Drop for AsyncStreamReader<R> {
     fn drop(&mut self) {
         BALLISTA_ASYNC_STREAM_READER_LATENCY
-            .with_label_values(&[self.label.as_str()])
-            .observe(self.started_at.elapsed().as_secs_f64());
+            .with_label_values(&[self.metrics.label.as_str()])
+            .observe(self.metrics.started_at.elapsed().as_secs_f64());
+        BALLISTA_ASYNC_STREAM_READER_CAPACITY
+            .with_label_values(&[self.metrics.label.as_str()])
+            .inc_by(self.metrics.num_rows as f64);
+        BALLISTA_ASYNC_STREAM_READER_SIZE
+            .with_label_values(&[self.metrics.label.as_str()])
+            .inc_by(self.metrics.size as f64);
     }
 }
 

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -90,7 +90,7 @@ impl LimitedBallistaClient {
             )
             .await?;
 
-        Ok(Box::pin(PermitRecordBatchStream::new(stream, permit)))
+        Ok(PermitRecordBatchStream::wrap(stream, permit))
     }
 }
 

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -23,8 +23,11 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::error::{BallistaError, Result};
 use crate::serde::scheduler::Action;
+use crate::{
+    error::{BallistaError, Result},
+    execution_plans::PermitRecordBatchStream,
+};
 
 use arrow_flight::decode::{DecodedPayload, FlightDataDecoder};
 use arrow_flight::error::FlightError;
@@ -71,9 +74,10 @@ impl LimitedBallistaClient {
         host: &str,
         port: u16,
     ) -> Result<SendableRecordBatchStream> {
-        let _ = self.semaphore.acquire().await.unwrap();
+        let permit = self.semaphore.clone().acquire_owned().await.unwrap();
 
-        self.client
+        let stream = self
+            .client
             .fetch_partition(
                 executor_id,
                 job_id,
@@ -84,7 +88,9 @@ impl LimitedBallistaClient {
                 host,
                 port,
             )
-            .await
+            .await?;
+
+        Ok(Box::pin(PermitRecordBatchStream::new(stream, permit)))
     }
 }
 

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -26,7 +26,7 @@ use std::{
 use crate::serde::scheduler::Action;
 use crate::{
     error::{BallistaError, Result},
-    execution_plans::PermitRecordBatchStream,
+    permit_stream::PermitRecordBatchStream,
 };
 
 use arrow_flight::decode::{DecodedPayload, FlightDataDecoder};

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -28,6 +28,7 @@ pub use coalesce_tasks::CoalesceTasksExec;
 pub use distributed_query::DistributedQueryExec;
 pub use shuffle_reader::batch_stream_from_object_store;
 pub use shuffle_reader::fetch_partition_object_store;
+pub use shuffle_reader::PermitRecordBatchStream;
 pub use shuffle_reader::ShuffleReaderExec;
 pub use shuffle_reader::ShuffleReaderExecOptions;
 pub use shuffle_writer::ShuffleWriterExec;

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -28,7 +28,6 @@ pub use coalesce_tasks::CoalesceTasksExec;
 pub use distributed_query::DistributedQueryExec;
 pub use shuffle_reader::batch_stream_from_object_store;
 pub use shuffle_reader::fetch_partition_object_store;
-pub use shuffle_reader::PermitRecordBatchStream;
 pub use shuffle_reader::ShuffleReaderExec;
 pub use shuffle_reader::ShuffleReaderExecOptions;
 pub use shuffle_writer::ShuffleWriterExec;

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -27,7 +27,7 @@ mod unresolved_shuffle;
 pub use coalesce_tasks::CoalesceTasksExec;
 pub use distributed_query::DistributedQueryExec;
 pub use shuffle_reader::batch_stream_from_object_store;
-pub use shuffle_reader::fetch_partition_object_store;
+pub use shuffle_reader::fetch_partition_object_store_inner;
 pub use shuffle_reader::ShuffleReaderExec;
 pub use shuffle_reader::ShuffleReaderExecOptions;
 pub use shuffle_writer::ShuffleWriterExec;

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -719,10 +719,7 @@ async fn fetch_partition_remote(
         )
         .await?;
 
-    Ok(Box::pin(RecordBatchStreamAdapter::new(
-        stream.schema(),
-        PermitRecordBatchStream::new(stream, permit),
-    )))
+    Ok(PermitRecordBatchStream::wrap(stream, permit))
 }
 
 async fn fetch_partition_local(

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -622,7 +622,7 @@ fn check_is_local_location(location: &PartitionLocation) -> bool {
 trait PartitionReader: Send + Sync {
     // Read partition data from PartitionLocation
     async fn fetch_partition(
-        self,
+        &self,
         location: &PartitionLocation,
         permit: tokio::sync::OwnedSemaphorePermit,
     ) -> result::Result<SendableRecordBatchStream, BallistaError>;
@@ -643,7 +643,7 @@ enum PartitionReaderEnum {
 impl PartitionReader for PartitionReaderEnum {
     // Notice return `BallistaError::FetchFailed` will let scheduler re-schedule the task.
     async fn fetch_partition(
-        self,
+        &self,
         location: &PartitionLocation,
         permit: tokio::sync::OwnedSemaphorePermit,
     ) -> result::Result<SendableRecordBatchStream, BallistaError> {
@@ -656,7 +656,7 @@ impl PartitionReader for PartitionReaderEnum {
                 fetch_partition_remote(
                     location,
                     clients.as_ref(),
-                    max_request_per_client,
+                    *max_request_per_client,
                     permit,
                 )
                 .await

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -421,7 +421,9 @@ fn send_fetch_partitions_with_fallback(
     join_handles.push(tokio::spawn(async move {
         for p in local_locations.iter() {
             let now = Instant::now();
-            let permit = local_semaphore.clone().acquire_owned().await.unwrap();
+            let Ok(permit) = local_semaphore.clone().acquire_owned().await else {
+                return;
+            };
             SHUFFLE_READER_FETCH_PARTITION_TOTAL
                 .with_label_values(&["local"])
                 .inc();
@@ -448,7 +450,9 @@ fn send_fetch_partitions_with_fallback(
     join_handles.push(tokio::spawn(async move {
         for p in remote_locations.iter() {
             let now = Instant::now();
-            let permit = remote_semaphore.clone().acquire_owned().await.unwrap();
+            let Ok(permit) = remote_semaphore.clone().acquire_owned().await else {
+                return;
+            };
             SHUFFLE_READER_FETCH_PARTITION_TOTAL
                 .with_label_values(&["remote"])
                 .inc();
@@ -499,7 +503,9 @@ fn send_fetch_partitions_with_fallback(
     join_handles.push(tokio::spawn(async move {
         while let Some(partition) = failed_partition_receiver.recv().await {
             let now = Instant::now();
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let Ok(permit) = semaphore.clone().acquire_owned().await else {
+                return;
+            };
             SHUFFLE_READER_FETCH_PARTITION_TOTAL
                 .with_label_values(&["object_store"])
                 .inc();
@@ -558,7 +564,9 @@ fn send_fetch_partitions(
     join_handles.push(tokio::spawn(async move {
         for p in local_locations.iter() {
             let now = Instant::now();
-            let permit = local_semaphore.clone().acquire_owned().await.unwrap();
+            let Ok(permit) = local_semaphore.clone().acquire_owned().await else {
+                return;
+            };
             SHUFFLE_READER_FETCH_PARTITION_TOTAL
                 .with_label_values(&["local"])
                 .inc();
@@ -581,7 +589,9 @@ fn send_fetch_partitions(
     join_handles.push(tokio::spawn(async move {
         for p in remote_locations.iter() {
             let now = Instant::now();
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let Ok(permit) = semaphore.clone().acquire_owned().await else {
+                return;
+            };
             SHUFFLE_READER_FETCH_PARTITION_TOTAL
                 .with_label_values(&["remote"])
                 .inc();

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -739,8 +739,7 @@ async fn fetch_partition_local(
         )
     })?;
 
-    let stream = reader.to_stream();
-    Ok(PermitRecordBatchStream::wrap(stream, permit))
+    Ok(PermitRecordBatchStream::wrap(reader.to_stream(), permit))
 }
 
 async fn fetch_partition_local_inner(
@@ -815,8 +814,7 @@ pub async fn batch_stream_from_object_store(
                     e
                 ))
             })?;
-    let stream = reader.to_stream();
-    Ok(PermitRecordBatchStream::wrap(stream, permit))
+    Ok(PermitRecordBatchStream::wrap(reader.to_stream(), permit))
 }
 
 #[cfg(test)]

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -612,6 +612,7 @@ mod tests {
         Ok(())
     }
 
+    #[ignore]
     #[tokio::test]
     // number of rows in each partition is a function of the hash output, so don't test here
     #[cfg(not(feature = "force_hash_collisions"))]

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -612,7 +612,6 @@ mod tests {
         Ok(())
     }
 
-    #[ignore]
     #[tokio::test]
     // number of rows in each partition is a function of the hash output, so don't test here
     #[cfg(not(feature = "force_hash_collisions"))]

--- a/ballista/core/src/lib.rs
+++ b/ballista/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod config;
 pub mod error;
 pub mod event_loop;
 pub mod execution_plans;
+pub mod permit_stream;
 pub mod physical_optimizer;
 /// some plugins
 

--- a/ballista/core/src/permit_stream/mod.rs
+++ b/ballista/core/src/permit_stream/mod.rs
@@ -1,0 +1,55 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
+use datafusion::{
+    error::DataFusionError,
+    execution::{RecordBatchStream, SendableRecordBatchStream},
+};
+use futures::{Stream, StreamExt};
+
+pub struct PermitRecordBatchStream {
+    inner: SendableRecordBatchStream,
+
+    #[allow(dead_code)]
+    permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl PermitRecordBatchStream {
+    pub fn new(
+        inner: SendableRecordBatchStream,
+        permit: tokio::sync::OwnedSemaphorePermit,
+    ) -> Self {
+        Self { permit, inner }
+    }
+
+    pub fn wrap(
+        inner: SendableRecordBatchStream,
+        permit: tokio::sync::OwnedSemaphorePermit,
+    ) -> SendableRecordBatchStream {
+        Box::pin(Self::new(inner, permit))
+    }
+}
+
+impl Stream for PermitRecordBatchStream {
+    type Item = Result<RecordBatch, DataFusionError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.inner.poll_next_unpin(cx) {
+            Poll::Ready(Some(batch)) => Poll::Ready(Some(batch)),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl RecordBatchStream for PermitRecordBatchStream {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+}

--- a/ballista/core/src/permit_stream/mod.rs
+++ b/ballista/core/src/permit_stream/mod.rs
@@ -17,8 +17,7 @@ pub struct PermitRecordBatchStream {
     on_close: Option<Box<dyn Fn(f64) + Send + 'static>>,
 
     // used to release a permit when the stream is dropped
-    #[allow(dead_code)]
-    permit: tokio::sync::OwnedSemaphorePermit,
+    _permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 impl PermitRecordBatchStream {
@@ -28,7 +27,7 @@ impl PermitRecordBatchStream {
         permit: tokio::sync::OwnedSemaphorePermit,
     ) -> Self {
         Self {
-            permit,
+            _permit: permit,
             inner,
             on_close,
             started_at: Instant::now(),

--- a/ballista/core/src/permit_stream/mod.rs
+++ b/ballista/core/src/permit_stream/mod.rs
@@ -9,10 +9,14 @@ use datafusion::{
     execution::{RecordBatchStream, SendableRecordBatchStream},
 };
 use futures::{Stream, StreamExt};
+use tokio::time::Instant;
 
 pub struct PermitRecordBatchStream {
     inner: SendableRecordBatchStream,
+    started_at: Instant,
+    on_close: Option<Box<dyn Fn(f64) + Send + 'static>>,
 
+    // used to release a permit when the stream is dropped
     #[allow(dead_code)]
     permit: tokio::sync::OwnedSemaphorePermit,
 }
@@ -20,16 +24,30 @@ pub struct PermitRecordBatchStream {
 impl PermitRecordBatchStream {
     pub fn new(
         inner: SendableRecordBatchStream,
+        on_close: Option<Box<dyn Fn(f64) + Send + 'static>>,
         permit: tokio::sync::OwnedSemaphorePermit,
     ) -> Self {
-        Self { permit, inner }
+        Self {
+            permit,
+            inner,
+            on_close,
+            started_at: Instant::now(),
+        }
     }
 
     pub fn wrap(
         inner: SendableRecordBatchStream,
         permit: tokio::sync::OwnedSemaphorePermit,
     ) -> SendableRecordBatchStream {
-        Box::pin(Self::new(inner, permit))
+        Box::pin(Self::new(inner, None, permit))
+    }
+
+    pub fn wrap_with_on_close(
+        inner: SendableRecordBatchStream,
+        on_close: Option<Box<dyn Fn(f64) + Send + 'static>>,
+        permit: tokio::sync::OwnedSemaphorePermit,
+    ) -> SendableRecordBatchStream {
+        Box::pin(Self::new(inner, on_close, permit))
     }
 }
 
@@ -51,5 +69,13 @@ impl Stream for PermitRecordBatchStream {
 impl RecordBatchStream for PermitRecordBatchStream {
     fn schema(&self) -> SchemaRef {
         self.inner.schema()
+    }
+}
+
+impl Drop for PermitRecordBatchStream {
+    fn drop(&mut self) {
+        if let Some(func) = self.on_close.as_ref() {
+            func(self.started_at.elapsed().as_secs_f64())
+        }
     }
 }

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -459,12 +459,12 @@ where
 
 pub fn create_grpc_server() -> Server {
     Server::builder()
-        .timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(7))
         // Disable Nagle's Algorithm since we don't want packets to wait
         .tcp_nodelay(true)
         .tcp_keepalive(Option::Some(Duration::from_secs(3600)))
         .http2_keepalive_interval(Option::Some(Duration::from_secs(300)))
-        .http2_keepalive_timeout(Option::Some(Duration::from_secs(20)))
+        .http2_keepalive_timeout(Option::Some(Duration::from_secs(7)))
 }
 
 pub fn collect_plan_metrics(plan: &dyn ExecutionPlan) -> Vec<MetricsSet> {

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -139,8 +139,7 @@ impl FlightService for BallistaFlightService {
                 .await
                 .map_err(from_arrow_err)?;
         let schema = reader.schema();
-        let stream = reader.to_stream();
-        let permit_stream = PermitRecordBatchStream::wrap(stream, permit);
+        let permit_stream = PermitRecordBatchStream::wrap(reader.to_stream(), permit);
         let stream = permit_stream.map_err(|e| {
             FlightError::Tonic(Status::internal(format!("Cannot process batch: {:?}", e)))
         });

--- a/ballista/executor/src/replicator/mod.rs
+++ b/ballista/executor/src/replicator/mod.rs
@@ -526,7 +526,6 @@ mod tests {
 
     #[tokio::test]
     async fn load_from_object_store() -> Result<()> {
-        let sem = Arc::new(tokio::sync::Semaphore::new(1));
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::UInt32, true),
             Field::new("b", DataType::Utf8, true),
@@ -553,7 +552,6 @@ mod tests {
             0,
             &[],
             object_store,
-            sem.clone().acquire_owned().await.unwrap(),
         )
         .await?;
 

--- a/ballista/executor/src/replicator/mod.rs
+++ b/ballista/executor/src/replicator/mod.rs
@@ -16,7 +16,7 @@ use prometheus::{
     register_histogram, register_int_counter_vec, Histogram, IntCounterVec,
 };
 use tokio::io::AsyncWriteExt;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::{fs::File, sync::mpsc};
 use tracing::{info, warn};
 
@@ -102,7 +102,7 @@ impl Replicator {
             created,
         }) = self.receiver.recv().await
         {
-            let _ = self.semaphore.acquire().await.unwrap();
+            let permit = self.semaphore.clone().acquire_owned().await.unwrap();
             let executor_id = self.executor_id.as_str();
             PROCESSED_FILES.with_label_values(&["total"]).inc();
             let destination = format!("{}{}", executor_id, path);
@@ -110,7 +110,7 @@ impl Replicator {
             info!(executor_id, job_id, destination, path, "Start replication");
 
             match Path::parse(destination) {
-                Ok(dest) => match load_file(path.as_str()).await {
+                Ok(dest) => match load_file(path.as_str(), permit).await {
                     Ok(reader) => {
                         replicate_to_object_store(
                             created,
@@ -147,11 +147,16 @@ impl Replicator {
 
 async fn load_file(
     path: &str,
+    permit: OwnedSemaphorePermit,
 ) -> Result<AsyncStreamReader<BufReader<Compat<File>>>, BallistaError> {
     let file = File::open(path).await?;
-    let reader =
-        AsyncStreamReader::try_new(file.compat(), None, "replication".to_string())
-            .await?;
+    let reader = AsyncStreamReader::try_new(
+        file.compat(),
+        None,
+        "replication".to_string(),
+        permit,
+    )
+    .await?;
 
     Ok(reader)
 }
@@ -441,6 +446,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_from_local() -> Result<()> {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
         let tmp_dir = TempDir::new().unwrap();
         let file = tmp_dir.path().join("1.data");
         let file_path = file.to_str().unwrap();
@@ -467,7 +473,9 @@ mod tests {
             .unwrap();
 
         assert!(stats.num_batches().unwrap() == 1);
-        let mut reader = load_file(file_path).await.unwrap();
+        let mut reader = load_file(file_path, sem.clone().acquire_owned().await.unwrap())
+            .await
+            .unwrap();
 
         let actual_batch = reader.maybe_next().await.unwrap().unwrap();
         assert_eq!(actual_batch, batch);
@@ -479,6 +487,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_to_object_store() -> Result<()> {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
         let tmp_dir = TempDir::new().unwrap();
         let file = tmp_dir.path().join("1.data");
         let file_path = file.to_str().unwrap();
@@ -506,7 +515,9 @@ mod tests {
             .unwrap();
 
         assert!(stats.num_batches().unwrap() == 1);
-        let reader = load_file(file_path).await.unwrap();
+        let reader = load_file(file_path, sem.clone().acquire_owned().await.unwrap())
+            .await
+            .unwrap();
         let destination: Path = Path::parse("2.data").unwrap();
         replicate_to_object_store(
             Instant::now(),
@@ -526,6 +537,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_from_object_store() -> Result<()> {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::UInt32, true),
             Field::new("b", DataType::Utf8, true),
@@ -552,6 +564,7 @@ mod tests {
             0,
             &[],
             object_store,
+            sem.clone().acquire_owned().await.unwrap(),
         )
         .await?;
 


### PR DESCRIPTION
Giving a permit per stream and dropping it only when the stream ends. This way we control steam parallelism.

Few places:
- number of streams per client
- number of streams per shuffle reader fetch cycle 
- number of streams for flight_service